### PR TITLE
Publish routed models into five more coding clients, and keep them current

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2305,6 +2305,27 @@ of somebody else's file; `routed-harness-manager.mjs` is the publisher.
   Command Code first reads `providers.json` in 1.30.0, so `minimumVersion` on
   its catalog entry makes setup update an older CLI and makes status and doctor
   report one. A version the CLI will not report is unknown, not outdated.
+- **Staying current is its own action, and it runs the client's own updater.**
+  `@latest` in `npmPackage` only decides what a *first* install fetches;
+  `installRoutedHarness` deliberately leaves a CLI that is already there alone,
+  because bumping somebody's global coding agent must not be a consequence of
+  republishing a model list. `control client-update <id>|--all`, the Harness
+  row's **Update** button, and `updateRoutedHarness` are the paths that do it.
+  Each prefers the client's own updater (`opencode upgrade`, `pi update
+  --self`, `command-code update`, `hermes update --yes`) over `npm install -g`:
+  a CLI installed by Homebrew or a `curl | sh` script is not an npm package,
+  and reinstalling it as one leaves two copies whose winner is PATH order —
+  which shows up as a row reporting the new version while the shell keeps
+  running the old one. npm is the fallback only for a client that publishes a
+  package and ships no updater. `--all` skips a client that is not installed
+  (update what I have, not install five agents I never asked for) and reports
+  per client rather than stopping at the first failure. A client that reports
+  no version before and after is never called "updated".
+- **Check the package name is still the maintained one.** pi moved publishers:
+  `@mariozechner/pi-coding-agent` stopped at 0.73.1 and the live line is
+  `@earendil-works/pi-coding-agent`. An abandoned package still installs and
+  still answers `pi --version`, so nothing in this repository would have
+  reported it as wrong — only reading the client's own install docs does.
 - **Prove a publication against the real client, not against its docs.** The
   unit suite passed while opencode 1.18 rejected every published model, because
   its schema requires `limit.output` whenever `limit` is present. opencode now

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2311,7 +2311,10 @@ of somebody else's file; `routed-harness-manager.mjs` is the publisher.
   gets `limit.input` at the router's `autoCompact` and `limit.output` as the
   headroom above it, or no `limit` when there is no threshold. A change to any
   adapter needs the same check: publish into a scratch document, then have the
-  installed client list or use the models from it.
+  installed client list the models from it and take one real turn (a free route
+  costs nothing). Listing alone missed that OpenCode's post-completion `ping`
+  had become a trailing gateway error: Codex ignores bytes after a terminal
+  event, and opencode and pi do not.
 - **Devin CLI and T3 Code are deliberately absent.** Devin CLI's config selects
   from Cognition-hosted models and has no custom base URL, so routed models
   cannot be published into it; the `devin-cli` *provider* is the other

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,11 @@ These instructions apply when a user asks an agent to install this repository.
   (Gemini CLI), `cursor` (Cursor Agent plus Cursor App), and `claude` (Claude
   Code through the router-owned launcher), and `openclaw` (OpenClaw through a
   router-owned Responses provider) are supported
-  targets. OpenCode remains a provider rather than a client target.
+  targets. OpenCode is not a `MODEL_ROUTER_TARGET`: it is both a provider and
+  one of the five *published-into* clients described under "Five clients,
+  one publisher, one key each" below, which `control client-setup` writes a
+  custom provider into rather than installing a target for. A published-into client never gets its
+  own service, state directory, or credential store.
 - Cursor is asymmetric: Cursor Agent uses the router's authenticated loopback
   Connect adapter, while retail Cursor App sends BYOK traffic through Cursor's
   servers and therefore needs an explicit stable public HTTPS tunnel to the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2295,10 +2295,23 @@ of somebody else's file; `routed-harness-manager.mjs` is the publisher.
   is partial.
 - **Installing the client CLI is still the explicit action it is for the
   harness.** Only `client-setup` installs, and only from a package registry.
-  Hermes ships a `curl | bash` installer; this router does not run remote
-  installers on somebody's behalf, so that row reports the CLI as missing and
-  links to the official instructions. omp publishes darwin-arm64 and linux-x64
-  builds only, so the button is offered only where a build exists.
+  Hermes ships a `curl | bash` installer and omp (can1357/oh-my-pi, whose npm
+  package runs on Bun) installs from a script, Homebrew, or Bun; this router
+  does not run remote installers on somebody's behalf, so those rows report the
+  CLI as missing and link to the official instructions. Do not point the omp
+  row at `@oh-labs/oh-omp`: that fork installs `oh-omp` and reads `~/.oh-omp`,
+  not the `~/.omp` the `omp` command reads.
+- **A client too old to read the document is updated, not published past.**
+  Command Code first reads `providers.json` in 1.30.0, so `minimumVersion` on
+  its catalog entry makes setup update an older CLI and makes status and doctor
+  report one. A version the CLI will not report is unknown, not outdated.
+- **Prove a publication against the real client, not against its docs.** The
+  unit suite passed while opencode 1.18 rejected every published model, because
+  its schema requires `limit.output` whenever `limit` is present. opencode now
+  gets `limit.input` at the router's `autoCompact` and `limit.output` as the
+  headroom above it, or no `limit` when there is no threshold. A change to any
+  adapter needs the same check: publish into a scratch document, then have the
+  installed client list or use the models from it.
 - **Devin CLI and T3 Code are deliberately absent.** Devin CLI's config selects
   from Cognition-hosted models and has no custom base URL, so routed models
   cannot be published into it; the `devin-cli` *provider* is the other

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2238,6 +2238,75 @@ user has to find in the docs, so `src/dsh-install.mjs` owns the other half.
   `test/dsh-config-manager.test.mjs`.
 
 
+## Five clients, one publisher, one key each
+
+opencode, pi, omp, Command Code, and Hermes Agent all offer the same thing: a
+user-owned configuration document with a mapping of custom providers in it.
+That is why they share `src/routed-harness-*.mjs` rather than getting five
+near-identical managers. `routed-harness-catalog.mjs` is the part that
+genuinely differs and it is data; `routed-harness-document.mjs` edits one key
+of somebody else's file; `routed-harness-manager.mjs` is the publisher.
+
+- **The wire is one the router already serves, never a third one.** The caller
+  endpoint answers `/v1/responses` and, behind the `/anthropic` leaf, the
+  Anthropic Messages API. Nothing else — there is no `/chat/completions`. So
+  opencode, pi, and omp declare a Responses provider, while Command Code and
+  Hermes take the Anthropic surface with `claude-model-id.mjs` ids. Command
+  Code's BYOK wire is Chat Completions or Anthropic Messages and Hermes's
+  `codex_responses` is its xAI path, not a generic Responses client; picking
+  the "OpenAI-compatible" option for either would have published a provider
+  that 404s on its first turn. `test/routed-harness.test.mjs` asserts no
+  adapter ever emits `openai-completions`.
+- **The capability is the URL, not the key.** The caller secret is a path
+  segment, so a bearer is redundant. Where a client treats a keyless provider
+  as first-class it is declared keyless (`auth: none` for omp, `apiKey: false`
+  for Command Code, omitted for Hermes); where a client *hides* keyless models
+  from its own picker — pi loads them and leaves them unselectable — the same
+  secret is repeated in the field it reads. That difference is not cosmetic: it
+  decides whether the models show up at all. Every published document is
+  written 0600 either way, because the URL is the capability.
+- **These are not `MODEL_ROUTER_TARGET` values.** Nothing installs *as*
+  opencode. They are published into by `control client-setup <id>` and removed
+  by `control client-disconnect <id>`, and neither touches the service.
+  `installedTargets()` still counts them, so `bin/disable` will not retire the
+  shared plane while one of them is pointed at it.
+- **A `codex-router` provider we did not write is never replaced or removed.**
+  Ownership is decided by the base URL, not by the key name: a second checkout,
+  an older build, or a hand-written proxy can legitimately hold that name.
+  Install and disconnect both refuse rather than guess.
+- **YAML is spliced, JSON is round-tripped, and neither is reformatted.**
+  `omp` and Hermes are edited by line range through `yaml-structure.mjs`, which
+  is what preserves comments and hand-formatting. JSON documents go through
+  `JSON.parse`, which cannot preserve a `//` comment — so a document that is
+  not plain JSON is refused with an explanation, and an `opencode.jsonc` beside
+  `opencode.json` blocks publication rather than being rewritten or ignored.
+- **The default model is the user's.** opencode is the only one of the five
+  whose default key is a plain string in the same document; the others keep
+  theirs in a second file or behind a mapping whose schema changes shape on
+  first use, and guessing wrong there costs a user their configured model for
+  no gain. Even there it is claimed only over a value this router wrote, or
+  when nothing is set, and removed on disconnect only while it is still ours.
+- **A failed marker write rolls the document back.** A client pointed at a
+  route the router has no record of is the one state neither disconnect nor
+  drift detection can reason about.
+- **Rotation covers all five.** The secret is a path segment of every published
+  base URL, so `caller-key.mjs` refreshes each of them and
+  `installedTargetsFromStatus` refuses to rotate across one whose managed state
+  is partial.
+- **Installing the client CLI is still the explicit action it is for the
+  harness.** Only `client-setup` installs, and only from a package registry.
+  Hermes ships a `curl | bash` installer; this router does not run remote
+  installers on somebody's behalf, so that row reports the CLI as missing and
+  links to the official instructions. omp publishes darwin-arm64 and linux-x64
+  builds only, so the button is offered only where a build exists.
+- **Devin CLI and T3 Code are deliberately absent.** Devin CLI's config selects
+  from Cognition-hosted models and has no custom base URL, so routed models
+  cannot be published into it; the `devin-cli` *provider* is the other
+  direction and already exists. T3 Code drives official CLIs rather than
+  talking to models itself, so it inherits whatever routed client it drives —
+  see `docs/COMPATIBLE-APPS.md`. Neither gets a Harness row, because a row that
+  cannot publish is a row that lies.
+
 ## Native GPT for a client with no ChatGPT login of its own
 
 Native traffic is authorized by the caller's session: `nativeHeaders` copies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **Muse Spark Responses turns no longer end in a gateway error.** OpenCode Go
+  and Zen send `event: ping` (`{"type":"ping","cost":"0"}`) after every
+  `response.completed`. The API forwarder treated it as data after the terminal
+  event and appended `invalid_responses_stream`, which LiteLLM re-raised as
+  `Response API in-stream error` on every completed `opencode-go-responses` and
+  `opencode-free-responses` turn. Codex ignores bytes after a terminal event, so
+  it went unnoticed; opencode and pi validate them and failed every turn. A
+  keep-alive or SSE comment after the terminal event is now dropped; real data
+  after it is still refused.
 - **A routed model the router has not loaded now fails locally, not at
   ChatGPT.** A model added to or renamed in `user-models.json` shows up in the
   Codex picker as soon as the catalog is rebuilt, but the running router reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- **Routed coding clients can be kept current from the Harness page.**
+  `control client-update <id>` and `control client-update --all`, plus an
+  **Update** button on each row and **Update all** in the header, move
+  opencode, pi, Command Code, and Hermes Agent to their latest release. Each
+  runs that client's own updater (`opencode upgrade`, `pi update --self`,
+  `command-code update`, `hermes update --yes`) rather than `npm install -g`,
+  so a CLI installed by Homebrew or a `curl | sh` script is updated in place
+  instead of gaining a second npm copy that may win or lose on PATH. omp ships
+  neither a package this router installs nor a self-update subcommand, so its
+  row prints the project's own three installs. Updating stays a separate,
+  explicit action: publishing a model list never changes a client's version.
+  `--all` skips clients that are not installed and reports each one instead of
+  stopping at the first failure.
+- **pi is installed from its maintained package.** The pi coding agent moved
+  from `@mariozechner/pi-coding-agent` (last published at 0.73.1) to
+  `@earendil-works/pi-coding-agent`. Setup installed the abandoned name, which
+  still installs and still answers `pi --version`, so the stale agent looked
+  healthy. pi's own `--ignore-scripts` install flag is used as well.
 - **Muse Spark Responses turns no longer end in a gateway error.** OpenCode Go
   and Zen send `event: ping` (`{"type":"ping","cost":"0"}`) after every
   `response.completed`. The API forwarder treated it as data after the terminal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,26 @@
   A native 401 is also preserved with a sanitized local error, allowing Codex's
   own ChatGPT authentication recovery to refresh the session and retry without
   exposing the upstream response body.
+- **Five more coding clients can be published to from the Harness page.**
+  opencode, pi, omp (oh-my-pi), Command Code, and Hermes Agent each keep their
+  providers in a configuration document the user also owns, so one shared
+  publisher (`src/routed-harness-*.mjs`) writes the single `codex-router`
+  provider key each of them reads and leaves every other byte alone.
+  **Set up** installs the client's CLI where this router can and publishes the
+  whole routed catalog in one action; `control client-setup <id>` and
+  `control client-disconnect <id>` are the same thing from a terminal. Clients
+  that speak the Responses API reach the authenticated loopback `/v1` path with
+  the router's own slugs; Command Code and Hermes, which have no Responses
+  client, reach the same Anthropic Messages surface Claude Code uses with
+  `codex_router/anthropic/<slug>` ids. Enabling a provider, storing a key, or
+  curating a model republishes all five alongside the existing clients, and a
+  caller-capability rotation refreshes them. YAML documents are spliced by line
+  range so comments and sibling providers survive; a JSON document the router
+  cannot round-trip is refused rather than reformatted; a `codex-router`
+  provider whose base URL this router did not issue is never replaced or
+  removed; and opencode's default model is claimed only when the user has not
+  chosen one. Devin CLI and T3 Code are deliberately not rows: Devin CLI has no
+  custom base URL, and T3 Code drives whichever official CLI is already routed.
 
 - **Command Code forced tool choices now use the same bounded alias as the tool definition.**
   The 64-character compatibility added in #643 shortened provider-facing tool names but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,8 +258,10 @@
   providers in a configuration document the user also owns, so one shared
   publisher (`src/routed-harness-*.mjs`) writes the single `codex-router`
   provider key each of them reads and leaves every other byte alone.
-  **Set up** installs the client's CLI where this router can and publishes the
-  whole routed catalog in one action; `control client-setup <id>` and
+  **Set up** installs the client's CLI where this router can (updating a
+  Command Code older than 1.30.0, the first release that reads
+  `providers.json`) and publishes the whole routed catalog in one action; omp
+  and Hermes install from their own instructions first; `control client-setup <id>` and
   `control client-disconnect <id>` are the same thing from a terminal. Clients
   that speak the Responses API reach the authenticated loopback `/v1` path with
   the router's own slugs; Command Code and Hermes, which have no Responses

--- a/README.md
+++ b/README.md
@@ -2327,6 +2327,69 @@ service only when no installed client still uses it.
 and provider credentials so routine removal cannot destroy authentication or
 recovery data.
 
+## Make models appear in opencode, pi, omp, Command Code, and Hermes Agent
+
+Five more coding clients keep their providers in a configuration document you
+also own. The Control Center's Harness page lists each of them, and **Set up**
+is the whole integration: install the client's CLI when this router can, then
+write the one provider key the router owns into that document.
+
+| Client | Document the router edits | Wire | Install |
+| --- | --- | --- | --- |
+| opencode | `~/.config/opencode/opencode.json` | Responses | `opencode-ai` |
+| pi | `~/.pi/agent/models.json` | Responses | `@mariozechner/pi-coding-agent` |
+| omp (oh-my-pi) | `~/.oh-omp/agent/models.yml` | Responses | `@oh-labs/oh-omp` (macOS and Linux builds only) |
+| Command Code | `~/.commandcode/providers.json` | Anthropic Messages | `command-code` |
+| Hermes Agent | `~/.hermes/config.yaml` | Anthropic Messages | install Hermes yourself first |
+
+From the terminal, the same action is one command per client:
+
+```sh
+./bin/control client-setup opencode
+./bin/control client-setup pi
+./bin/control client-setup omp
+./bin/control client-setup commandcode
+./bin/control client-setup hermes
+
+./bin/control client-disconnect opencode
+```
+
+Each client is published *into* rather than installed *as*: there is no
+`MODEL_ROUTER_TARGET` for these five and no second service. They share the
+router plane every other client uses, so enabling a provider, storing a key, or
+curating a model republishes all of them together and no picker is left
+advertising a model the others just lost.
+
+**The wire is one the router already serves.** Clients that speak the Responses
+API are pointed at the authenticated loopback `/v1` path with the router's own
+slugs. Command Code and Hermes have no Responses client, so they are pointed at
+the same Anthropic Messages surface Claude Code uses, with
+`codex_router/anthropic/<router-slug>` ids. No client is handed a protocol the
+router does not implement.
+
+**The router owns one key and nothing else.** That is
+`provider.codex-router` (opencode, Command Code) or `providers.codex-router`
+(pi, omp, Hermes), plus a private publication marker in the router's own state
+directory. YAML documents are spliced by line range rather than parsed and
+rewritten, so comments, hand-formatting, and every sibling provider survive a
+publish. A JSON document the router cannot round-trip — one carrying `//`
+comments, or an `opencode.jsonc` sitting beside `opencode.json` — is refused
+with an explanation rather than reformatted.
+
+A `codex-router` provider whose base URL this router did not issue is treated
+as somebody else's: both setup and disconnect refuse rather than overwrite it.
+opencode's default model is claimed only when you have not chosen one, and is
+released again the moment you pick your own. Every published document is
+written `0600`, because the base URL carries the local caller capability as a
+path segment.
+
+Removing one of these clients never retires the shared service while another
+client is still pointed at it:
+
+```sh
+./bin/control client-disconnect hermes
+```
+
 ## Updates and rollback
 
 For a managed Git checkout:

--- a/README.md
+++ b/README.md
@@ -2337,7 +2337,7 @@ write the one provider key the router owns into that document.
 | Client | Document the router edits | Wire | Install |
 | --- | --- | --- | --- |
 | opencode | `~/.config/opencode/opencode.json` | Responses | `opencode-ai` |
-| pi | `~/.pi/agent/models.json` | Responses | `@mariozechner/pi-coding-agent` |
+| pi | `~/.pi/agent/models.json` | Responses | `@earendil-works/pi-coding-agent` |
 | omp (oh-my-pi) | `~/.omp/agent/models.yml` | Responses | install omp yourself first ([omp.sh](https://omp.sh/); it runs on Bun) |
 | Command Code | `~/.commandcode/providers.json` | Anthropic Messages | `command-code` 1.30.0 or later (setup updates an older one) |
 | Hermes Agent | `~/.hermes/config.yaml` | Anthropic Messages | install Hermes yourself first |
@@ -2358,6 +2358,25 @@ From the terminal, the same action is one command per client:
 
 ./bin/control client-disconnect opencode
 ```
+
+**Keeping them current is its own command.** Setup installs a client that is
+missing, but deliberately leaves one that is already there at the version you
+have — bumping a global coding agent is not something that should happen
+because you republished a model list. To move them:
+
+```sh
+./bin/control client-update opencode   # runs `opencode upgrade`
+./bin/control client-update --all      # every client you actually have
+```
+
+Each runs the client's *own* updater (`opencode upgrade`, `pi update --self`,
+`command-code update`, `hermes update --yes`) rather than `npm install -g`, so
+a CLI you installed with Homebrew or a `curl | sh` script is updated in place
+instead of gaining a second npm copy that may win or lose on PATH. omp has
+neither, so its row prints the project's own installs. `--all` skips clients
+you have not installed and reports each one rather than stopping at the first
+failure. The Harness page has the same thing as an **Update** button per row
+and **Update all** in the header.
 
 Each client is published *into* rather than installed *as*: there is no
 `MODEL_ROUTER_TARGET` for these five and no second service. They share the

--- a/README.md
+++ b/README.md
@@ -2338,9 +2338,14 @@ write the one provider key the router owns into that document.
 | --- | --- | --- | --- |
 | opencode | `~/.config/opencode/opencode.json` | Responses | `opencode-ai` |
 | pi | `~/.pi/agent/models.json` | Responses | `@mariozechner/pi-coding-agent` |
-| omp (oh-my-pi) | `~/.oh-omp/agent/models.yml` | Responses | `@oh-labs/oh-omp` (macOS and Linux builds only) |
-| Command Code | `~/.commandcode/providers.json` | Anthropic Messages | `command-code` |
+| omp (oh-my-pi) | `~/.omp/agent/models.yml` | Responses | install omp yourself first ([omp.sh](https://omp.sh/); it runs on Bun) |
+| Command Code | `~/.commandcode/providers.json` | Anthropic Messages | `command-code` 1.30.0 or later (setup updates an older one) |
 | Hermes Agent | `~/.hermes/config.yaml` | Anthropic Messages | install Hermes yourself first |
+
+opencode honours `OPENCODE_CONFIG`, pi and omp both honour
+`PI_CODING_AGENT_DIR`, and omp's `models.yaml` is edited in place when it has
+no `models.yml` beside it, so the router writes the file each client actually
+reads.
 
 From the terminal, the same action is one command per client:
 

--- a/apps/control-center/electron/api.d.ts
+++ b/apps/control-center/electron/api.d.ts
@@ -41,6 +41,10 @@ export interface HarnessDescriptor {
   configured: boolean;
   canInstall: boolean;
   installRequirement?: string;
+  /** Whether this client is installed and has an updater this router can run. */
+  canUpdate?: boolean;
+  /** The command an update would run, e.g. `opencode upgrade`. */
+  updateCommand?: string;
   publicOrigin?: string;
   agentConfigured?: boolean;
   appConfigured?: boolean;
@@ -221,6 +225,8 @@ export interface RouterControl {
   probeAgentBridge(bridgeId: AgentBridgeId): Promise<unknown>;
   loginAgentBridge(bridgeId: AgentBridgeId): Promise<unknown>;
   setupHarness(harnessId: HarnessId, hostname?: string): Promise<unknown>;
+  /** Move one routed client, or every installed one ("all"), to its latest release. */
+  updateHarness(harnessId: HarnessId | "all"): Promise<unknown>;
   prepareCursorTunnel(): Promise<unknown>;
   connectCursor(hostname?: string): Promise<unknown>;
   openHarnessSession(harnessId: HarnessId, sessionId: string, surface: HarnessSurface, model?: string): Promise<unknown>;

--- a/apps/control-center/electron/api.d.ts
+++ b/apps/control-center/electron/api.d.ts
@@ -3,13 +3,37 @@ export type SubagentMode = "all" | "selected" | "proven";
 export type VisionEffort = "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra" | "default";
 export type ServiceAction = "status" | "start";
 export type TrayAction = "enable" | "disable" | "status" | "restart";
-export type HarnessId = "codex" | "dsh" | "gemini" | "cursor" | "claude" | "openclaw";
+export type HarnessId =
+  | "codex"
+  | "dsh"
+  | "gemini"
+  | "cursor"
+  | "claude"
+  | "openclaw"
+  // Document-configured harnesses: published into rather than installed as.
+  // See `src/routed-harness-catalog.mjs`.
+  | "opencode"
+  | "pi"
+  | "omp"
+  | "commandcode"
+  | "hermes";
 export type HarnessSurface = "app" | "terminal";
 
 export interface HarnessDescriptor {
   id: HarnessId;
   displayName: string;
-  ownership: "openai" | "deepseek" | "google" | "cursor" | "anthropic" | "openclaw";
+  ownership:
+    | "openai"
+    | "deepseek"
+    | "google"
+    | "cursor"
+    | "anthropic"
+    | "openclaw"
+    | "opencode"
+    | "pi"
+    | "omp"
+    | "commandcode"
+    | "nousresearch";
   description: string;
   cliInstalled: boolean;
   cliVersion?: string;
@@ -75,7 +99,7 @@ export interface HarnessSession {
 export interface ContextSessionsSnapshot {
   fetchedAt: string;
   sessions: HarnessSession[];
-  counts: { total: number; codex: number; dsh: number; cursor: number; claude: number; gemini: number; openclaw: number; archived: number };
+  counts: { total: number; codex: number; dsh: number; cursor: number; claude: number; gemini: number; openclaw: number; opencode: number; pi: number; omp: number; commandcode: number; hermes: number; archived: number };
 }
 
 export interface ChatGptSessionStatus {

--- a/apps/control-center/electron/ipc.mjs
+++ b/apps/control-center/electron/ipc.mjs
@@ -107,14 +107,14 @@ const ROUTED_HARNESS_ROWS = Object.freeze([
     displayName: "omp",
     ownership: "omp",
     description: "The omp (oh-my-pi) terminal agent, using every model selected in this router.",
-    executables: Object.freeze(["omp", "oh-omp"]),
+    executables: Object.freeze(["omp"]),
     marker: "omp-models.json",
-    site: "https://github.com/open-horizon-labs/oh-omp",
-    docs: "https://github.com/open-horizon-labs/oh-omp/blob/main/docs/models.md",
-    // The published package carries prebuilt binaries for darwin-arm64 and
-    // linux-x64 only, so the install button is offered only where one exists.
-    installable: process.platform === "darwin" || process.platform === "linux",
-    installHint: "Setup installs @oh-labs/oh-omp when it is missing and publishes every routed model.",
+    site: "https://omp.sh/",
+    docs: "https://github.com/can1357/oh-my-pi/blob/main/docs/models.md",
+    // omp runs on Bun and installs from its own script, Homebrew, or Bun, none
+    // of which this router runs on somebody's behalf. The row links to them.
+    installable: false,
+    installHint: "Install omp from omp.sh first; setup then publishes every routed model into ~/.omp/agent/models.yml.",
     publishHint: "Publishes every routed model into omp's models.yml. Comments and every other provider are preserved.",
   }),
   Object.freeze({
@@ -128,7 +128,7 @@ const ROUTED_HARNESS_ROWS = Object.freeze([
     site: "https://commandcode.ai/",
     docs: "https://commandcode.ai/docs/byok",
     installable: true,
-    installHint: "Setup installs command-code when it is missing and publishes every routed model as a BYOK provider.",
+    installHint: "Setup installs command-code 1.30.0 or later (the first release that reads providers.json) and publishes every routed model as a BYOK provider.",
     publishHint: "Publishes every routed model into ~/.commandcode/providers.json. Your Command Code plan and its own models are untouched.",
   }),
   Object.freeze({

--- a/apps/control-center/electron/ipc.mjs
+++ b/apps/control-center/electron/ipc.mjs
@@ -84,6 +84,7 @@ const ROUTED_HARNESS_ROWS = Object.freeze([
     site: "https://opencode.ai/",
     docs: "https://opencode.ai/docs/config/",
     installable: true,
+    updater: "opencode upgrade",
     installHint: "Setup installs opencode-ai when it is missing and publishes every routed model.",
     publishHint: "Publishes every routed model into opencode's router-owned provider. Other opencode settings remain untouched.",
   }),
@@ -98,7 +99,8 @@ const ROUTED_HARNESS_ROWS = Object.freeze([
     site: "https://pi.dev/",
     docs: "https://pi.dev/docs/latest/models",
     installable: true,
-    installHint: "Setup installs @mariozechner/pi-coding-agent when it is missing and publishes every routed model.",
+    updater: "pi update --self",
+    installHint: "Setup installs @earendil-works/pi-coding-agent when it is missing and publishes every routed model.",
     publishHint: "Publishes every routed model into pi's models.json. Every other provider in that file is preserved.",
   }),
   Object.freeze({
@@ -114,6 +116,7 @@ const ROUTED_HARNESS_ROWS = Object.freeze([
     // omp runs on Bun and installs from its own script, Homebrew, or Bun, none
     // of which this router runs on somebody's behalf. The row links to them.
     installable: false,
+    updater: null,
     installHint: "Install omp from omp.sh first; setup then publishes every routed model into ~/.omp/agent/models.yml.",
     publishHint: "Publishes every routed model into omp's models.yml. Comments and every other provider are preserved.",
   }),
@@ -128,6 +131,10 @@ const ROUTED_HARNESS_ROWS = Object.freeze([
     site: "https://commandcode.ai/",
     docs: "https://commandcode.ai/docs/byok",
     installable: true,
+    // `command-code`, not the `cmd` alias the docs use: `cmd` is the Windows
+    // command shell, so Command Code ships as `cmdc` there. The full name is
+    // the one that resolves on every platform, and the one this router runs.
+    updater: "command-code update",
     installHint: "Setup installs command-code 1.30.0 or later (the first release that reads providers.json) and publishes every routed model as a BYOK provider.",
     publishHint: "Publishes every routed model into ~/.commandcode/providers.json. Your Command Code plan and its own models are untouched.",
   }),
@@ -145,6 +152,7 @@ const ROUTED_HARNESS_ROWS = Object.freeze([
     // registry, and this router does not run remote installers on somebody's
     // behalf. The row links to the official instructions instead.
     installable: false,
+    updater: "hermes update --yes",
     installHint: "Install the official Hermes Agent first; setup then publishes every routed model into its config.yaml.",
     publishHint: "Publishes every routed model as the codex-router provider in Hermes's config.yaml. Every other setting is preserved.",
   }),
@@ -541,6 +549,11 @@ export function getHarnessSnapshot() {
           configured: existsSync(path.join(stateDirectory, row.marker)),
           canInstall: row.installable || Boolean(binary),
           installRequirement: binary ? row.publishHint : row.installHint,
+          // Updating is offered only for a client that is actually here and has
+          // something to run. It is never implied by setup: bumping a global
+          // coding agent is its own decision, so it gets its own button.
+          canUpdate: Boolean(binary) && Boolean(row.updater || row.installable),
+          ...(row.updater ? { updateCommand: row.updater } : {}),
           docsUrl: row.docs,
         };
       }),
@@ -2202,6 +2215,25 @@ export function registerIpcHandlers({
       if (binary) environmentOverrides[routedSetup.binEnv] = binary;
     }
     return controlJsonRunner(args, {
+      timeoutMs: REPAIR_TIMEOUT_MS,
+      ...(Object.keys(environmentOverrides).length ? { environmentOverrides } : {}),
+    });
+  });
+  // Move one routed client, or every installed one, to its latest release.
+  //
+  // A fixed command with a validated id; the renderer supplies no executable
+  // and no argv. It is deliberately not folded into `setupHarness`: publishing
+  // a model list must never be the reason somebody's global coding agent
+  // changed version underneath them.
+  handleAction("updateHarness", async ({ harnessId } = {}) => {
+    const harness = harnessId === "all" ? "--all" : oneOf(harnessId, ROUTED_HARNESS_IDS, "Harness");
+    const environmentOverrides = {};
+    const routed = ROUTED_HARNESS_ROWS.find((row) => row.id === harness);
+    if (routed) {
+      const binary = routed.executables.map((name) => harnessExecutableResolver(name)).find(Boolean);
+      if (binary) environmentOverrides[routed.binEnv] = binary;
+    }
+    return controlJsonRunner(["client-update", harness], {
       timeoutMs: REPAIR_TIMEOUT_MS,
       ...(Object.keys(environmentOverrides).length ? { environmentOverrides } : {}),
     });

--- a/apps/control-center/electron/ipc.mjs
+++ b/apps/control-center/electron/ipc.mjs
@@ -67,7 +67,90 @@ const SESSION_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3
 const CURSOR_SESSION_ID = /^(?:(?:draft|bc)-)?[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SESSION_UUID_IN_FILENAME = /[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
 const DSH_SESSION_ID = /^session-[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-const HARNESS_IDS = ["codex", "dsh", "gemini", "cursor", "claude", "openclaw"];
+// The five document-configured harnesses this router publishes into. The
+// authority is `src/routed-harness-catalog.mjs`; this table is the renderer's
+// copy of the parts a detection-only pass needs, kept here for the same reason
+// `HARNESS_SITES` and the docs URLs below are — the app must be able to draw
+// the Harness tab before it can load a module out of the installed router.
+const ROUTED_HARNESS_ROWS = Object.freeze([
+  Object.freeze({
+    id: "opencode",
+    binEnv: "OPENCODE_BIN",
+    displayName: "opencode",
+    ownership: "opencode",
+    description: "The opencode terminal agent, using every model selected in this router.",
+    executables: Object.freeze(["opencode"]),
+    marker: "opencode-models.json",
+    site: "https://opencode.ai/",
+    docs: "https://opencode.ai/docs/config/",
+    installable: true,
+    installHint: "Setup installs opencode-ai when it is missing and publishes every routed model.",
+    publishHint: "Publishes every routed model into opencode's router-owned provider. Other opencode settings remain untouched.",
+  }),
+  Object.freeze({
+    id: "pi",
+    binEnv: "PI_BIN",
+    displayName: "pi",
+    ownership: "pi",
+    description: "Mario Zechner's pi coding agent, using every model selected in this router.",
+    executables: Object.freeze(["pi"]),
+    marker: "pi-models.json",
+    site: "https://pi.dev/",
+    docs: "https://pi.dev/docs/latest/models",
+    installable: true,
+    installHint: "Setup installs @mariozechner/pi-coding-agent when it is missing and publishes every routed model.",
+    publishHint: "Publishes every routed model into pi's models.json. Every other provider in that file is preserved.",
+  }),
+  Object.freeze({
+    id: "omp",
+    binEnv: "OMP_BIN",
+    displayName: "omp",
+    ownership: "omp",
+    description: "The omp (oh-my-pi) terminal agent, using every model selected in this router.",
+    executables: Object.freeze(["omp", "oh-omp"]),
+    marker: "omp-models.json",
+    site: "https://github.com/open-horizon-labs/oh-omp",
+    docs: "https://github.com/open-horizon-labs/oh-omp/blob/main/docs/models.md",
+    // The published package carries prebuilt binaries for darwin-arm64 and
+    // linux-x64 only, so the install button is offered only where one exists.
+    installable: process.platform === "darwin" || process.platform === "linux",
+    installHint: "Setup installs @oh-labs/oh-omp when it is missing and publishes every routed model.",
+    publishHint: "Publishes every routed model into omp's models.yml. Comments and every other provider are preserved.",
+  }),
+  Object.freeze({
+    id: "commandcode",
+    binEnv: "COMMANDCODE_BIN",
+    displayName: "Command Code",
+    ownership: "commandcode",
+    description: "Command Code's CLI as a BYOK client of this router's Anthropic surface.",
+    executables: Object.freeze(process.platform === "win32" ? ["command-code", "cmdc"] : ["command-code", "cmd"]),
+    marker: "commandcode-models.json",
+    site: "https://commandcode.ai/",
+    docs: "https://commandcode.ai/docs/byok",
+    installable: true,
+    installHint: "Setup installs command-code when it is missing and publishes every routed model as a BYOK provider.",
+    publishHint: "Publishes every routed model into ~/.commandcode/providers.json. Your Command Code plan and its own models are untouched.",
+  }),
+  Object.freeze({
+    id: "hermes",
+    binEnv: "HERMES_BIN",
+    displayName: "Hermes Agent",
+    ownership: "nousresearch",
+    description: "Nous Research's Hermes Agent as a named custom provider on this router.",
+    executables: Object.freeze(["hermes"]),
+    marker: "hermes-models.json",
+    site: "https://hermes-agent.nousresearch.com/",
+    docs: "https://hermes-agent.nousresearch.com/docs/integrations/providers",
+    // Hermes installs from its own shell script rather than a package
+    // registry, and this router does not run remote installers on somebody's
+    // behalf. The row links to the official instructions instead.
+    installable: false,
+    installHint: "Install the official Hermes Agent first; setup then publishes every routed model into its config.yaml.",
+    publishHint: "Publishes every routed model as the codex-router provider in Hermes's config.yaml. Every other setting is preserved.",
+  }),
+]);
+const ROUTED_HARNESS_IDS = ROUTED_HARNESS_ROWS.map((row) => row.id);
+const HARNESS_IDS = ["codex", "dsh", "gemini", "cursor", "claude", "openclaw", ...ROUTED_HARNESS_IDS];
 const HARNESS_SURFACES = ["app", "terminal"];
 const AGENT_BRIDGE_IDS = ["anthropic", "cursor", "gemini"];
 const SESSION_INDEX_LIMIT = 16 * 1024 * 1024;
@@ -121,6 +204,7 @@ const HARNESS_SITES = Object.freeze({
   cursor: "https://cursor.com/",
   claude: "https://claude.com/product/claude-code",
   gemini: "https://google-gemini.github.io/gemini-cli/",
+  ...Object.fromEntries(ROUTED_HARNESS_ROWS.map((row) => [row.id, row.site])),
 });
 const OAUTH_LOGIN_COMMANDS = Object.freeze({
   "kimi-oauth": { executable: "kimi", args: ["login"] },
@@ -439,6 +523,27 @@ export function getHarnessSnapshot() {
         ...(typeof cursorState?.publicOrigin === "string" ? { publicOrigin: cursorState.publicOrigin } : {}),
         docsUrl: CURSOR_DOCS,
       },
+      // Detection only: this runs on every page load, so it reads a marker and
+      // looks for an executable and does nothing else. Whether a routed
+      // harness is *correctly* published is a question for its own status
+      // command, which costs a process and is asked when a row is acted on.
+      ...ROUTED_HARNESS_ROWS.map((row) => {
+        const binary = row.executables.map((name) => executablePath(name)).find(Boolean);
+        const version = executableVersion(binary);
+        return {
+          id: row.id,
+          displayName: row.displayName,
+          ownership: row.ownership,
+          description: row.description,
+          cliInstalled: Boolean(binary),
+          ...(version ? { cliVersion: version } : {}),
+          appInstalled: false,
+          configured: existsSync(path.join(stateDirectory, row.marker)),
+          canInstall: row.installable || Boolean(binary),
+          installRequirement: binary ? row.publishHint : row.installHint,
+          docsUrl: row.docs,
+        };
+      }),
     ],
   };
 }
@@ -1087,6 +1192,9 @@ export function getContextSessionsSnapshot() {
       claude: sessions.filter((session) => session.harnessId === "claude").length,
       gemini: sessions.filter((session) => session.harnessId === "gemini").length,
       openclaw: 0,
+      // None of the routed harnesses writes a session index this app can read,
+      // so their rows report no sessions rather than an invented number.
+      ...Object.fromEntries(ROUTED_HARNESS_IDS.map((id) => [id, 0])),
       archived: sessions.filter((session) => session.archived).length,
     },
   };
@@ -2012,20 +2120,24 @@ export function registerIpcHandlers({
       return { opened: true, surface: "app" };
     }
     if (destination === "app") return openOfficialSite();
-    const executable = executablePath(
-      harness === "codex" ? "codex"
-        : harness === "dsh" ? "dsh"
-          : harness === "claude" ? "claude-router"
-            : harness === "gemini" ? "gemini"
-              : harness === "openclaw" ? "openclaw"
-              : "cursor-router-agent",
-    );
-    const label = harness === "codex" ? "Codex"
-      : harness === "dsh" ? "DeepSeek Harness"
-        : harness === "claude" ? "Claude Code Router"
-          : harness === "gemini" ? "Gemini CLI"
-            : harness === "openclaw" ? "OpenClaw"
-            : "Cursor Router Agent";
+    const routed = ROUTED_HARNESS_ROWS.find((row) => row.id === harness);
+    const executable = routed
+      ? routed.executables.map((name) => harnessExecutableResolver(name)).find(Boolean)
+      : executablePath(
+        harness === "codex" ? "codex"
+          : harness === "dsh" ? "dsh"
+            : harness === "claude" ? "claude-router"
+              : harness === "gemini" ? "gemini"
+                : harness === "openclaw" ? "openclaw"
+                : "cursor-router-agent",
+      );
+    const label = routed ? routed.displayName
+      : harness === "codex" ? "Codex"
+        : harness === "dsh" ? "DeepSeek Harness"
+          : harness === "claude" ? "Claude Code Router"
+            : harness === "gemini" ? "Gemini CLI"
+              : harness === "openclaw" ? "OpenClaw"
+              : "Cursor Router Agent";
     if (!executable) throw new Error(`${label} CLI is not installed or configured.`);
     return openTerminalCommand(executable, [], discoverSourceRoot());
   }, { requiresCompatibleRouter: false });
@@ -2079,6 +2191,15 @@ export function registerIpcHandlers({
     if (harness === "openclaw") {
       const openclaw = harnessExecutableResolver("openclaw");
       if (openclaw) environmentOverrides.OPENCLAW_BIN = openclaw;
+    }
+    // A desktop app does not inherit the login shell's PATH. Detection above
+    // already checked the standard per-user CLI directories, so hand the exact
+    // executable it found to the router rather than asking a child with a
+    // narrower PATH to discover it a second time.
+    const routedSetup = ROUTED_HARNESS_ROWS.find((row) => row.id === harness);
+    if (routedSetup) {
+      const binary = routedSetup.executables.map((name) => harnessExecutableResolver(name)).find(Boolean);
+      if (binary) environmentOverrides[routedSetup.binEnv] = binary;
     }
     return controlJsonRunner(args, {
       timeoutMs: REPAIR_TIMEOUT_MS,

--- a/apps/control-center/electron/preload.cjs
+++ b/apps/control-center/electron/preload.cjs
@@ -70,6 +70,7 @@ const routerControl = Object.freeze({
   probeAgentBridge: (bridgeId) => call("probeAgentBridge", { bridgeId }),
   loginAgentBridge: (bridgeId) => call("loginAgentBridge", { bridgeId }),
   setupHarness: (harnessId, hostname) => call("setupHarness", { harnessId, hostname }),
+  updateHarness: (harnessId) => call("updateHarness", { harnessId }),
   prepareCursorTunnel: () => call("prepareCursorTunnel"),
   connectCursor: (hostname) => call("connectCursor", { hostname }),
   openHarnessSession: (harnessId, sessionId, surface, model) => call("openHarnessSession", { harnessId, sessionId, surface, model }),

--- a/apps/control-center/src/assets/clients/SOURCES.md
+++ b/apps/control-center/src/assets/clients/SOURCES.md
@@ -12,7 +12,7 @@ Research was refreshed on 2026-08-30.
 | `claude.svg` | Claude Code | https://claude.com/product/claude-code | Exact orange Claude mark bundled in the installed official Anthropic Claude app (`ion-dist/assets/v1/cd02a42d9-Vq_H3mgS.svg`) |
 | `openclaw.svg` | OpenClaw | https://github.com/openclaw/openclaw | Official `docs/assets/pixel-lobster.svg` from the OpenClaw repository |
 | `pi.svg` | pi | https://pi.dev/ | The official `favicon.svg` served by pi.dev, reflowed onto one line and otherwise unchanged |
-| `omp.svg` | omp (oh-my-pi) | https://github.com/open-horizon-labs/oh-omp | Official `assets/icon.svg` from the oh-omp repository, with its fills replaced by `currentColor` for the mask below |
+| `omp.svg` | omp (oh-my-pi) | https://omp.sh/ | Official `assets/icon.svg` from the can1357/oh-my-pi repository, with its fills replaced by `currentColor` for the mask below |
 
 Three client rows reuse a mark this app already bundles for the same
 organization as a *provider*, rather than committing a second copy of it:

--- a/apps/control-center/src/assets/clients/SOURCES.md
+++ b/apps/control-center/src/assets/clients/SOURCES.md
@@ -11,8 +11,19 @@ Research was refreshed on 2026-08-30.
 | `codex-light.svg`, `codex-dark.svg` | Codex | https://developers.openai.com/ | Dedicated `icon-codex-light.png` and `icon-codex-dark-color.png` product assets bundled in the installed official OpenAI desktop app, mechanically downsampled for this 23px surface |
 | `claude.svg` | Claude Code | https://claude.com/product/claude-code | Exact orange Claude mark bundled in the installed official Anthropic Claude app (`ion-dist/assets/v1/cd02a42d9-Vq_H3mgS.svg`) |
 | `openclaw.svg` | OpenClaw | https://github.com/openclaw/openclaw | Official `docs/assets/pixel-lobster.svg` from the OpenClaw repository |
+| `pi.svg` | pi | https://pi.dev/ | The official `favicon.svg` served by pi.dev, reflowed onto one line and otherwise unchanged |
+| `omp.svg` | omp (oh-my-pi) | https://github.com/open-horizon-labs/oh-omp | Official `assets/icon.svg` from the oh-omp repository, with its fills replaced by `currentColor` for the mask below |
 
-DeepSeek Harness's official component is rendered as a current-colour mask.
+Three client rows reuse a mark this app already bundles for the same
+organization as a *provider*, rather than committing a second copy of it:
+opencode uses `../providers/opencode.png`, Command Code uses
+`../providers/commandcode.svg`, and Hermes Agent uses
+`../providers/nousresearch.png`. Their provenance is recorded in
+`../providers/SOURCES.md`.
+
+DeepSeek Harness's and omp's official components are rendered as current-colour
+masks. omp's mark is drawn for a dark ground, so painting it in the surrounding
+text colour is what keeps it legible in both themes.
 Cursor and Codex retain their official light/dark artwork. All names, logos, and trademarks remain
 the property of their respective owners. Their use here identifies compatible
 clients and does not imply endorsement or affiliation.

--- a/apps/control-center/src/assets/clients/omp.svg
+++ b/apps/control-center/src/assets/clients/omp.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 90" width="120" height="90">
+  <rect x="10" y="8" width="100" height="12" rx="2" fill="currentColor"/>
+  <rect x="25" y="20" width="12" height="62" rx="2" fill="currentColor"/>
+  <rect x="75" y="20" width="12" height="45" rx="2" fill="currentColor"/>
+  <rect x="71" y="55" width="20" height="16" rx="3" fill="currentColor"/>
+  <circle cx="18" cy="14" r="2" fill="currentColor"/>
+  <circle cx="102" cy="14" r="2" fill="currentColor"/>
+</svg>

--- a/apps/control-center/src/assets/clients/pi.svg
+++ b/apps/control-center/src/assets/clients/pi.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <rect width="800" height="800" rx="120" fill="#09090b"/>
+  <path fill="#fff" fill-rule="evenodd" d="M165.29 165.29 H517.36 V400 H400 V517.36 H282.65 V634.72 H165.29 Z M282.65 282.65 V400 H400 V282.65 Z"/>
+  <path fill="#fff" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
+</svg>

--- a/apps/control-center/src/pages/HarnessPage.tsx
+++ b/apps/control-center/src/pages/HarnessPage.tsx
@@ -16,6 +16,14 @@ import deepSeekHarnessLogo from "../assets/clients/deepseek-harness.svg";
 import claudeLogo from "../assets/clients/claude.svg";
 import geminiLogo from "../assets/providers/gemini.svg";
 import openclawLogo from "../assets/clients/openclaw.svg";
+import piLogo from "../assets/clients/pi.svg";
+import ompLogo from "../assets/clients/omp.svg";
+// opencode, Command Code, and Nous Research already ship a mark in this app as
+// *providers*. A client row is the same organization, so it reuses that asset
+// rather than committing a second copy that would then have to be kept in step.
+import opencodeLogo from "../assets/providers/opencode.png";
+import commandCodeLogo from "../assets/providers/commandcode.svg";
+import nousResearchLogo from "../assets/providers/nousresearch.png";
 import { Badge, Button, InlineNotice, PageHeader, PanelSkeleton, SectionHeading, StatStrip } from "../components";
 import type {
   AgentBridgeDescriptor,
@@ -43,7 +51,16 @@ interface HarnessPageProps {
   onNavigate: (view: ViewId) => void;
 }
 
-const CLIENT_ORDER: HarnessId[] = ["openclaw", "cursor", "claude", "gemini", "dsh", "codex"];
+// The six clients that predate the shared publisher keep their order; the five
+// document-configured harnesses follow, so an existing user's rows do not move
+// under them on upgrade.
+const CLIENT_ORDER: HarnessId[] = [
+  "openclaw", "cursor", "claude", "gemini", "dsh", "codex",
+  "opencode", "pi", "omp", "commandcode", "hermes",
+];
+// A routed harness has no desktop app, so its configured action opens a
+// terminal rather than falling through to the client's official website.
+const TERMINAL_ONLY_CLIENTS = new Set<HarnessId>(["opencode", "pi", "omp", "commandcode", "hermes"]);
 const CLIENT_LOGOS: Record<HarnessId, { light: string; dark?: string; mode: "artwork" | "mask" }> = {
   cursor: { light: cursorLogo, dark: cursorDarkLogo, mode: "artwork" },
   dsh: { light: deepSeekHarnessLogo, mode: "mask" },
@@ -51,6 +68,13 @@ const CLIENT_LOGOS: Record<HarnessId, { light: string; dark?: string; mode: "art
   claude: { light: claudeLogo, mode: "artwork" },
   gemini: { light: geminiLogo, mode: "artwork" },
   openclaw: { light: openclawLogo, mode: "artwork" },
+  opencode: { light: opencodeLogo, mode: "artwork" },
+  pi: { light: piLogo, mode: "artwork" },
+  // omp's official mark is drawn in near-white for a dark ground. Painting it
+  // in the surrounding text colour is what keeps it legible in both themes.
+  omp: { light: ompLogo, mode: "mask" },
+  commandcode: { light: commandCodeLogo, mode: "artwork" },
+  hermes: { light: nousResearchLogo, mode: "mask" },
 };
 
 export function HarnessPage({ target, api, refreshing, operation, onRefresh, runAction, onNavigate }: HarnessPageProps) {
@@ -125,7 +149,8 @@ export function HarnessPage({ target, api, refreshing, operation, onRefresh, run
   const setup = async (harness: HarnessDescriptor) => {
     if (!api) return;
     if (harness.configured) {
-      await act(`Open ${harness.displayName}`, () => api.launchHarness(harness.id, "app"));
+      const surface = TERMINAL_ONLY_CLIENTS.has(harness.id) && harness.cliInstalled ? "terminal" : "app";
+      await act(`Open ${harness.displayName}`, () => api.launchHarness(harness.id, surface));
       return;
     }
     if (harness.id === "cursor") {
@@ -156,7 +181,7 @@ export function HarnessPage({ target, api, refreshing, operation, onRefresh, run
       {error ? <InlineNotice tone="warning" title="Client detection is incomplete">{error}</InlineNotice> : null}
 
       <div className="lhc-harness-list">
-        {!snapshot && !error ? <PanelSkeleton label="Detecting coding clients" variant="list" count={6} /> : null}
+        {!snapshot && !error ? <PanelSkeleton label="Detecting coding clients" variant="list" count={CLIENT_ORDER.length} /> : null}
         {clients.length ? (
           <div className="lhc-harness-table-head" aria-hidden>
             <span>Client</span>
@@ -226,7 +251,7 @@ export function HarnessPage({ target, api, refreshing, operation, onRefresh, run
       </div>
 
       <section className="panel-section">
-        <SectionHeading title="One router plane, six client stores" description="Model routes and provider credentials are shared; sessions and client-owned settings remain separate." />
+        <SectionHeading title={`One router plane, ${clients.length} client stores`} description="Model routes and provider credentials are shared; sessions and client-owned settings remain separate." />
         <div className="lhc-continuity-map">
           <article>
             <Route aria-hidden size={18} strokeWidth={1.7} />

--- a/apps/control-center/src/pages/HarnessPage.tsx
+++ b/apps/control-center/src/pages/HarnessPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
 import {
   AppWindow,
+  ArrowUpCircle,
   Boxes,
   BrainCircuit,
   Globe2,
@@ -159,6 +160,17 @@ export function HarnessPage({ target, api, refreshing, operation, onRefresh, run
       await act(`Configure ${harness.displayName}`, () => api.setupHarness(harness.id));
     }
   };
+  // Updating is its own action, never a step inside setup: publishing a model
+  // list must not be the reason somebody's global coding agent changed version.
+  const update = async (harness: HarnessDescriptor) => {
+    if (!api?.updateHarness) return;
+    await act(`Update ${harness.displayName}`, () => api.updateHarness(harness.id));
+  };
+  const updatableClients = clients.filter((client) => client.canUpdate);
+  const updateAll = async () => {
+    if (!api?.updateHarness) return;
+    await act("Update installed clients", () => api.updateHarness("all"));
+  };
 
   return (
     <>
@@ -176,6 +188,16 @@ export function HarnessPage({ target, api, refreshing, operation, onRefresh, run
           { label: "Sessions", value: sessions?.counts.total ?? 0, detail: "Indexed metadata" },
           { label: "Routed models", value: routedModelCount, detail: "Shared picker" },
         ]} />
+        {updatableClients.length ? (
+          <Button
+            variant="secondary"
+            disabled={!api?.updateHarness}
+            title={`Runs each client's own updater for: ${updatableClients.map((client) => client.displayName).join(", ")}. Clients that are not installed are skipped.`}
+            onClick={() => void updateAll()}
+          >
+            <ArrowUpCircle aria-hidden size={14} strokeWidth={1.7} /> Update all ({updatableClients.length})
+          </Button>
+        ) : null}
       </div>
 
       {error ? <InlineNotice tone="warning" title="Client detection is incomplete">{error}</InlineNotice> : null}
@@ -244,6 +266,19 @@ export function HarnessPage({ target, api, refreshing, operation, onRefresh, run
                       ? <><AppWindow aria-hidden size={14} strokeWidth={1.7} /> Open</>
                       : <><Settings2 aria-hidden size={14} strokeWidth={1.7} /> {harness.id === "cursor" ? "Connect Cursor" : "Set up"}</>}
                 </Button>
+                {harness.canUpdate ? (
+                  <Button
+                    variant="ghost"
+                    aria-label={`Update ${harness.displayName}`}
+                    disabled={!api?.updateHarness}
+                    title={harness.updateCommand
+                      ? `Runs \`${harness.updateCommand}\``
+                      : `Reinstalls ${harness.displayName} at its latest release`}
+                    onClick={() => void update(harness)}
+                  >
+                    <ArrowUpCircle aria-hidden size={14} strokeWidth={1.7} /> Update
+                  </Button>
+                ) : null}
               </div>
             }
           />

--- a/apps/control-center/src/types.ts
+++ b/apps/control-center/src/types.ts
@@ -637,13 +637,37 @@ export interface OperationEvent {
   error?: string;
 }
 
-export type HarnessId = "codex" | "dsh" | "gemini" | "cursor" | "claude" | "openclaw";
+export type HarnessId =
+  | "codex"
+  | "dsh"
+  | "gemini"
+  | "cursor"
+  | "claude"
+  | "openclaw"
+  // Document-configured harnesses: published into rather than installed as.
+  // See `src/routed-harness-catalog.mjs`.
+  | "opencode"
+  | "pi"
+  | "omp"
+  | "commandcode"
+  | "hermes";
 export type HarnessSurface = "app" | "terminal";
 
 export interface HarnessDescriptor {
   id: HarnessId;
   displayName: string;
-  ownership: "openai" | "deepseek" | "google" | "cursor" | "anthropic" | "openclaw";
+  ownership:
+    | "openai"
+    | "deepseek"
+    | "google"
+    | "cursor"
+    | "anthropic"
+    | "openclaw"
+    | "opencode"
+    | "pi"
+    | "omp"
+    | "commandcode"
+    | "nousresearch";
   description: string;
   cliInstalled: boolean;
   cliVersion?: string;
@@ -722,6 +746,11 @@ export interface ContextSessionsSnapshot {
     claude: number;
     gemini: number;
     openclaw: number;
+    opencode: number;
+    pi: number;
+    omp: number;
+    commandcode: number;
+    hermes: number;
     archived: number;
   };
 }

--- a/apps/control-center/src/types.ts
+++ b/apps/control-center/src/types.ts
@@ -675,6 +675,10 @@ export interface HarnessDescriptor {
   configured: boolean;
   canInstall: boolean;
   installRequirement?: string;
+  /** Whether this client is installed and has an updater this router can run. */
+  canUpdate?: boolean;
+  /** The command an update would run, e.g. `opencode upgrade`. */
+  updateCommand?: string;
   publicOrigin?: string;
   agentConfigured?: boolean;
   appConfigured?: boolean;
@@ -832,6 +836,8 @@ export interface RouterControlApi {
   probeAgentBridge(bridgeId: AgentBridgeId): Promise<unknown>;
   loginAgentBridge(bridgeId: AgentBridgeId): Promise<unknown>;
   setupHarness(harnessId: HarnessId, hostname?: string): Promise<unknown>;
+  /** Move one routed client, or every installed one ("all"), to its latest release. */
+  updateHarness(harnessId: HarnessId | "all"): Promise<unknown>;
   prepareCursorTunnel(): Promise<unknown>;
   connectCursor(hostname?: string): Promise<unknown>;
   openHarnessSession(harnessId: HarnessId, sessionId: string, surface: HarnessSurface, model?: string): Promise<unknown>;

--- a/src/caller-key-rotation-journal.mjs
+++ b/src/caller-key-rotation-journal.mjs
@@ -3,10 +3,11 @@ import { existsSync, lstatSync, readFileSync, unlinkSync } from "node:fs";
 import path from "node:path";
 import { privateFileIsProtected, writePrivateJson } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
+import { ROUTED_HARNESS_IDS } from "./routed-harness-catalog.mjs";
 
 export const CALLER_KEY_ROTATION_JOURNAL_PATH = path.join(STATE_DIR, "caller-key-rotation.json");
 const PHASES = new Set(["prepared", "service-stopped", "secret-swapped", "clients-refreshed", "service-started", "verified"]);
-const TARGETS = new Set(["codex", "dsh", "gemini", "openclaw"]);
+const TARGETS = new Set(["codex", "dsh", "gemini", "openclaw", ...ROUTED_HARNESS_IDS]);
 const TRANSITIONS = Object.freeze({
   prepared: new Set(["service-stopped", "secret-swapped"]),
   "service-stopped": new Set(["secret-swapped"]),

--- a/src/caller-key.mjs
+++ b/src/caller-key.mjs
@@ -25,6 +25,7 @@ import { withServiceOperationLock } from "./service-operation-lock.mjs";
 import { runServiceCommandUnlocked } from "./service.mjs";
 import { CALLER_SECRET_PATH, PORTS } from "./paths.mjs";
 import { assertStateOwnership } from "./state-owner.mjs";
+import { ROUTED_HARNESS_IDS, routedHarnesses } from "./routed-harness-catalog.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const refreshCommand = Object.freeze({
@@ -32,6 +33,13 @@ const refreshCommand = Object.freeze({
   dsh: ["src/dsh-config-manager.mjs", ["caller-capability-refresh"]],
   gemini: ["src/gemini-config-manager.mjs", ["caller-capability-refresh"]],
   openclaw: ["src/openclaw-config-manager.mjs", ["caller-capability-refresh"]],
+  // The caller secret is a path segment of every published base URL, so a
+  // rotation invalidates each of these documents at once. One publisher serves
+  // all five, addressed by harness id.
+  ...Object.fromEntries(ROUTED_HARNESS_IDS.map((id) => [
+    id,
+    ["src/routed-harness-manager.mjs", [id, "caller-capability-refresh"]],
+  ])),
 });
 
 function secretDigest(secret) {
@@ -42,7 +50,8 @@ function partialClient(label) {
   throw new Error(`Refusing caller capability rotation while ${label} has partial managed state; run its doctor/repair path first.`);
 }
 
-export function installedTargetsFromStatus({ codex = {}, dsh = {}, gemini = {}, openclaw = {} } = {}) {
+export function installedTargetsFromStatus(statuses = {}) {
+  const { codex = {}, dsh = {}, gemini = {}, openclaw = {} } = statuses;
   const targets = [];
   const codexStatePresent = codex.provider_mode_state_present === true || codex.signed_provider_state_present === true;
   const codexManagedArtifacts = codex.managed_router_artifacts_present === true;
@@ -91,6 +100,26 @@ export function installedTargetsFromStatus({ codex = {}, dsh = {}, gemini = {}, 
     }
     targets.push("openclaw");
   }
+
+  // Each document-configured harness is published exactly when its marker is
+  // valid and its provider is live at a base URL this router issued. Anything
+  // in between is partial managed state, and rotating the capability across it
+  // would leave a client pointed at a URL that no longer authenticates with no
+  // record of how to put it back.
+  for (const harness of routedHarnesses()) {
+    const status = statuses[harness.id] || {};
+    const evidence = status.installed === true || status.providerInstalled === true;
+    if (!evidence) continue;
+    if (
+      status.installed !== true ||
+      status.providerInstalled !== true ||
+      status.baseUrlManaged !== true ||
+      status.configValid !== true
+    ) {
+      partialClient(harness.displayName);
+    }
+    targets.push(harness.id);
+  }
   return targets;
 }
 
@@ -120,6 +149,10 @@ export async function readManagedClientStatuses({ runNode = runNodeCommand } = {
     dsh: parseJsonCommand("src/dsh-config-manager.mjs", ["status"], runNode),
     gemini: parseJsonCommand("src/gemini-config-manager.mjs", ["status"], runNode),
     openclaw: parseJsonCommand("src/openclaw-config-manager.mjs", ["status"], runNode),
+    ...Object.fromEntries(ROUTED_HARNESS_IDS.map((id) => [
+      id,
+      parseJsonCommand("src/routed-harness-manager.mjs", [id, "status"], runNode),
+    ])),
   };
 }
 

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -3092,8 +3092,20 @@ async function handleHarness(action) {
 // enable entrypoint operators run from the terminal. OpenClaw's enable path
 // installs the official CLI when missing before it publishes the provider.
 async function handleClientSetup(target, publicUrl, hostname) {
-  if (!["codex", "dsh", "cursor", "claude", "openclaw"].includes(target)) {
-    throw new Error("Usage: control client-setup codex|dsh|cursor|claude|openclaw [--hostname PUBLIC_HOSTNAME|--public-url HTTPS_ORIGIN]");
+  const { ROUTED_HARNESS_IDS } = await import("./routed-harness-catalog.mjs");
+  if (![...["codex", "dsh", "cursor", "claude", "openclaw"], ...ROUTED_HARNESS_IDS].includes(target)) {
+    throw new Error("Usage: control client-setup codex|dsh|cursor|claude|openclaw|opencode|pi|omp|commandcode|hermes [--hostname PUBLIC_HOSTNAME|--public-url HTTPS_ORIGIN]");
+  }
+  // opencode, pi, omp, Command Code, and Hermes are published *into* rather
+  // than installed *as*: there is no `MODEL_ROUTER_TARGET` for them and no
+  // second service. Setup installs the client's CLI when this router can, then
+  // writes the one provider key it owns inside that client's own document.
+  if (ROUTED_HARNESS_IDS.includes(target)) {
+    if (publicUrl || hostname) throw new Error("--hostname and --public-url apply to Cursor only.");
+    const { createRoutedHarnessManager } = await import("./routed-harness-manager.mjs");
+    const result = createRoutedHarnessManager(target).install({ installMissingCli: true });
+    process.stdout.write(`${JSON.stringify({ target, configured: true, ...result })}\n`);
+    return;
   }
   if (target === "dsh") {
     if (publicUrl || hostname) throw new Error("--hostname and --public-url apply to Cursor only.");
@@ -3135,6 +3147,18 @@ async function handleClientSetup(target, publicUrl, hostname) {
     );
   }
   process.stdout.write(`${JSON.stringify({ target, configured: true })}\n`);
+}
+
+// Removing one published client is never a reason to tear the shared plane
+// down: `bin/disable` retires the service only once `installedTargets()` is
+// empty, and this command deliberately never touches the service at all.
+async function handleClientDisconnect(target) {
+  const { ROUTED_HARNESS_IDS } = await import("./routed-harness-catalog.mjs");
+  if (!ROUTED_HARNESS_IDS.includes(target)) {
+    throw new Error("Usage: control client-disconnect opencode|pi|omp|commandcode|hermes");
+  }
+  const { createRoutedHarnessManager } = await import("./routed-harness-manager.mjs");
+  process.stdout.write(`${JSON.stringify(createRoutedHarnessManager(target).uninstall())}\n`);
 }
 
 async function handleClientExport() {
@@ -3439,9 +3463,14 @@ if (args.includes("--probe")) {
   const publicUrl = optionValue("--public-url");
   const hostname = optionValue("--hostname");
   if ((publicUrl && hostname) || ((publicUrl || hostname) && args.length !== 4) || (!publicUrl && !hostname && args.length !== 2)) {
-    throw new Error("Usage: control client-setup codex|dsh|cursor|claude|openclaw [--hostname PUBLIC_HOSTNAME|--public-url HTTPS_ORIGIN]");
+    throw new Error("Usage: control client-setup codex|dsh|cursor|claude|openclaw|opencode|pi|omp|commandcode|hermes [--hostname PUBLIC_HOSTNAME|--public-url HTTPS_ORIGIN]");
   }
   await handleClientSetup(args[1], publicUrl, hostname);
+} else if (args[0] === "client-disconnect") {
+  if (args.length !== 2) {
+    throw new Error("Usage: control client-disconnect opencode|pi|omp|commandcode|hermes");
+  }
+  await handleClientDisconnect(args[1]);
 } else if (args[0] === "client-export") {
   await handleClientExport();
 } else if (args[0] === "presence") {

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -3161,6 +3161,44 @@ async function handleClientDisconnect(target) {
   process.stdout.write(`${JSON.stringify(createRoutedHarnessManager(target).uninstall())}\n`);
 }
 
+// Move one routed harness CLI, or all of them, to its latest release.
+//
+// Separate from `client-setup` on purpose. Setup publishes models and installs
+// a missing CLI; it deliberately leaves a CLI that is already there alone,
+// because bumping somebody's global agent is not a thing to do as a
+// consequence of republishing a model list. This is the command that says
+// "update it", and it is the only path that does.
+//
+// `--all` reports per client rather than stopping at the first failure: one
+// client with no updater, or a network blip on one package, is not a reason to
+// leave the other four on yesterday's build.
+async function handleClientUpdate(target) {
+  const { ROUTED_HARNESS_IDS } = await import("./routed-harness-catalog.mjs");
+  if (target !== "--all" && !ROUTED_HARNESS_IDS.includes(target)) {
+    throw new Error("Usage: control client-update opencode|pi|omp|commandcode|hermes|--all");
+  }
+  const { routedHarnessCliPath, updateRoutedHarness } = await import("./routed-harness-install.mjs");
+  if (target !== "--all") {
+    process.stdout.write(`${JSON.stringify(updateRoutedHarness(target), null, 2)}\n`);
+    return;
+  }
+  const results = [];
+  for (const id of ROUTED_HARNESS_IDS) {
+    // An absent client is skipped rather than installed: "update everything I
+    // have" must not become "install five coding agents I never asked for".
+    if (!routedHarnessCliPath(id)) {
+      results.push({ harness: id, skipped: "not installed" });
+      continue;
+    }
+    try {
+      results.push(updateRoutedHarness(id));
+    } catch (error) {
+      results.push({ harness: id, failed: error instanceof Error ? error.message : String(error) });
+    }
+  }
+  process.stdout.write(`${JSON.stringify({ updated: results }, null, 2)}\n`);
+}
+
 async function handleClientExport() {
   const values = args.slice(1);
   let secretEnv;
@@ -3471,6 +3509,11 @@ if (args.includes("--probe")) {
     throw new Error("Usage: control client-disconnect opencode|pi|omp|commandcode|hermes");
   }
   await handleClientDisconnect(args[1]);
+} else if (args[0] === "client-update") {
+  if (args.length !== 2) {
+    throw new Error("Usage: control client-update opencode|pi|omp|commandcode|hermes|--all");
+  }
+  await handleClientUpdate(args[1]);
 } else if (args[0] === "client-export") {
   await handleClientExport();
 } else if (args[0] === "presence") {

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -1440,6 +1440,62 @@ if (TARGET === "gemini") {
   );
 }
 
+// The five document-configured harnesses are published *into* rather than
+// installed *as*, so they belong to no `MODEL_ROUTER_TARGET` and would
+// otherwise be checked by no doctor run at all. They are reported here
+// whenever their publication marker says this router wrote into one of them,
+// whichever target this command happens to be running under.
+try {
+  const { routedHarnesses } = await import("./routed-harness-catalog.mjs");
+  const { ROUTED_HARNESS_CATALOG_PATHS } = await import("./paths.mjs");
+  for (const harness of routedHarnesses()) {
+    if (!existsSync(ROUTED_HARNESS_CATALOG_PATHS[harness.id])) continue;
+    const publishHint = `Run ./bin/control client-setup ${harness.id} to republish.`;
+    try {
+      const status = childJson("routed-harness-manager.mjs", [harness.id, "status"]);
+      add(
+        status.installed && status.providerInstalled && status.baseUrlManaged && status.configValid
+          ? "ok"
+          : "fail",
+        `${harness.displayName} routing config`,
+        status.configError
+          ? status.configError
+          : status.providerInstalled
+            ? `${status.publishedModels} models in ${harness.providerPath.join(".")}; ${status.baseUrl || "unmanaged endpoint"}`
+            : `the router-owned provider is missing from ${status.document}`,
+        publishHint,
+      );
+      add(
+        status.cliInstalled ? "ok" : "warn",
+        `${harness.displayName} CLI`,
+        status.cliInstalled ? status.cli || harness.executables[0] : "not installed",
+        `Use Harness > ${harness.displayName} > Set up, or install it from ${harness.siteUrl}.`,
+      );
+      add(
+        status.documentProtected ? "ok" : "fail",
+        `${harness.displayName} config privacy`,
+        status.documentProtected ? `${status.document} is private` : status.document,
+        `${publishHint} Its provider carries the local caller capability.`,
+      );
+      add(
+        status.catalogFresh ? "ok" : "warn",
+        `${harness.displayName} catalog freshness`,
+        `published ${status.publishedModels}, routable ${status.routableModels}`,
+        publishHint,
+      );
+    } catch (error) {
+      add(
+        "fail",
+        `${harness.displayName} routing config`,
+        error instanceof Error ? error.message : String(error),
+        publishHint,
+      );
+    }
+  }
+} catch {
+  // Never let a diagnostic be the thing that fails the doctor.
+}
+
 const legacy = detectLegacyInstallations();
 add(
   legacy.unknownConflict ? "fail" : legacy.installations.length ? "fail" : "ok",

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -1466,9 +1466,13 @@ try {
         publishHint,
       );
       add(
-        status.cliInstalled ? "ok" : "warn",
+        status.cliInstalled && !status.cliOutdated ? "ok" : "warn",
         `${harness.displayName} CLI`,
-        status.cliInstalled ? status.cli || harness.executables[0] : "not installed",
+        !status.cliInstalled
+          ? "not installed"
+          : status.cliOutdated
+            ? `${status.cliVersion} predates ${status.cliMinimumVersion}, the first release that reads the published provider`
+            : status.cli || harness.executables[0],
         `Use Harness > ${harness.displayName} > Set up, or install it from ${harness.siteUrl}.`,
       );
       add(

--- a/src/openai-adapters.mjs
+++ b/src/openai-adapters.mjs
@@ -406,8 +406,13 @@ function keepAliveFrame(frame, data) {
 }
 
 function normalizeResponsesEvent(frame, state, flatToNative) {
-  // An SSE comment, or a frame with no data line and no event, is not an event.
-  if (frame.data === "" && !frame.event) return "";
+  // An SSE comment, or a frame with no data line and no event, is not an event
+  // and is not forwarded. It is still proof the upstream was talking, so a
+  // stream that ends before its terminal event is still reported by `flush`.
+  if (frame.data === "" && !frame.event) {
+    state.sawEvent = true;
+    return "";
+  }
   const data = frameData(frame);
   state.sawEvent = true;
   if (state.invalid) return "";

--- a/src/openai-adapters.mjs
+++ b/src/openai-adapters.mjs
@@ -395,11 +395,26 @@ function rememberStreamIndex(state, key, index) {
   return true;
 }
 
+// A keep-alive carries no Responses semantics. OpenCode Go and Zen close every
+// stream with `event: ping` / `{"type":"ping","cost":"0"}` *after*
+// `response.completed`; treating it as post-terminal data appended
+// `invalid_responses_stream` to every completed turn, which LiteLLM re-raised
+// as "Response API in-stream error". Codex ignores bytes after a terminal
+// event; opencode's AI SDK and pi validate them and failed the turn.
+function keepAliveFrame(frame, data) {
+  return frame.event === "ping" || (data && typeof data === "object" && data.type === "ping");
+}
+
 function normalizeResponsesEvent(frame, state, flatToNative) {
+  // An SSE comment, or a frame with no data line and no event, is not an event.
+  if (frame.data === "" && !frame.event) return "";
   const data = frameData(frame);
   state.sawEvent = true;
   if (state.invalid) return "";
   if (state.terminal && data !== "[DONE]") {
+    // Real data after the terminal event is still refused. Only a keep-alive,
+    // which cannot change a finished response, is dropped.
+    if (keepAliveFrame(frame, data)) return "";
     return invalidStream(state, "The Responses stream emitted data after its terminal event.");
   }
   if (frame.event === "error") state.terminal = true;

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -95,6 +95,48 @@ export const CURSOR_LAUNCHER_PATH = process.env.MODEL_ROUTER_CURSOR_LAUNCHER || 
     ? path.join(process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local"), "codex-router", "bin", "cursor-router-agent.cmd")
     : path.join(os.homedir(), ".local", "bin", "cursor-router-agent")
 );
+// The five OpenAI/Anthropic-wire harnesses published by `routed-harness-*.mjs`.
+// Each one owns a single user-visible configuration document that the router
+// edits one key of; every path below resolves the way that client resolves it,
+// with a `MODEL_ROUTER_*` override so a test never writes into a real home.
+//
+// opencode reads a global config from `$XDG_CONFIG_HOME/opencode/opencode.json`
+// and lets `OPENCODE_CONFIG` name a file outright. Honour both, in that order,
+// or a user who moved theirs gets a provider nothing reads.
+export const OPENCODE_CONFIG_PATH =
+  process.env.MODEL_ROUTER_OPENCODE_CONFIG ||
+  process.env.OPENCODE_CONFIG ||
+  path.join(
+    process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config"),
+    "opencode",
+    "opencode.json",
+  );
+// pi keeps its agent state in `~/.pi/agent`; custom providers live in
+// `models.json` beside the session store.
+export const PI_AGENT_HOME = process.env.PI_AGENT_DIR || path.join(os.homedir(), ".pi", "agent");
+export const PI_MODELS_PATH =
+  process.env.MODEL_ROUTER_PI_MODELS || path.join(PI_AGENT_HOME, "models.json");
+// omp (oh-my-pi) resolves its agent directory from `PI_CODING_AGENT_DIR`,
+// defaulting to `~/.oh-omp/agent`. `models.yml` is the modern format; the
+// legacy `models.json` is still read but is not what a current install writes.
+export const OMP_AGENT_HOME =
+  process.env.PI_CODING_AGENT_DIR || path.join(os.homedir(), ".oh-omp", "agent");
+export const OMP_MODELS_PATH =
+  process.env.MODEL_ROUTER_OMP_MODELS || path.join(OMP_AGENT_HOME, "models.yml");
+// Command Code keeps BYOK provider declarations in their own document, apart
+// from `auth.json` where its own credentials live. The router only ever writes
+// the former, and never a raw secret into it.
+export const COMMANDCODE_HOME =
+  process.env.COMMANDCODE_HOME || path.join(os.homedir(), ".commandcode");
+export const COMMANDCODE_PROVIDERS_PATH =
+  process.env.MODEL_ROUTER_COMMANDCODE_PROVIDERS ||
+  path.join(COMMANDCODE_HOME, "providers.json");
+// Hermes Agent keeps every non-secret setting in one YAML document. Named
+// custom providers live under its `providers:` mapping.
+export const HERMES_HOME = process.env.HERMES_HOME || path.join(os.homedir(), ".hermes");
+export const HERMES_CONFIG_PATH =
+  process.env.MODEL_ROUTER_HERMES_CONFIG || path.join(HERMES_HOME, "config.yaml");
+
 export const CLAUDE_HOME = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
 export const CLAUDE_SETTINGS_PATH = path.join(CLAUDE_HOME, "settings.json");
 export const CLAUDE_LAUNCHER_PATH = process.env.MODEL_ROUTER_CLAUDE_LAUNCHER || (
@@ -135,6 +177,18 @@ export const GEMINI_CATALOG_PATH = path.join(STATE_DIR, "gemini-models.json");
 export const CURSOR_CATALOG_PATH = path.join(STATE_DIR, "cursor-models.json");
 export const CLAUDE_CATALOG_PATH = path.join(STATE_DIR, "claude-models.json");
 export const OPENCLAW_CATALOG_PATH = path.join(STATE_DIR, "openclaw-models.json");
+// One publication marker per routed harness, on the same rule as every other
+// client: it records what this router last wrote into somebody else's
+// document, so drift is detected against a snapshot rather than by
+// re-deriving what "should" be there and trusting the answer. Its presence is
+// what says the integration is installed.
+export const ROUTED_HARNESS_CATALOG_PATHS = Object.freeze({
+  opencode: path.join(STATE_DIR, "opencode-models.json"),
+  pi: path.join(STATE_DIR, "pi-models.json"),
+  omp: path.join(STATE_DIR, "omp-models.json"),
+  commandcode: path.join(STATE_DIR, "commandcode-models.json"),
+  hermes: path.join(STATE_DIR, "hermes-models.json"),
+});
 // Router-owned Cloudflare named-tunnel metadata. The tunnel exposes only the
 // separately keyed Cursor App edge on 4214; it never points at the main router.
 export const CURSOR_TUNNEL_STATE_PATH = path.join(STATE_DIR, "cursor-tunnel.json");

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -112,22 +113,29 @@ export const OPENCODE_CONFIG_PATH =
     "opencode.json",
   );
 // pi keeps its agent state in `~/.pi/agent`; custom providers live in
-// `models.json` beside the session store.
-export const PI_AGENT_HOME = process.env.PI_AGENT_DIR || path.join(os.homedir(), ".pi", "agent");
+// `models.json` beside the session store. Its override is
+// `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`, i.e. `PI_CODING_AGENT_DIR`
+// (read from the shipped `dist/config.js`, not guessed from the docs).
+export const PI_AGENT_HOME =
+  process.env.PI_CODING_AGENT_DIR || path.join(os.homedir(), ".pi", "agent");
 export const PI_MODELS_PATH =
   process.env.MODEL_ROUTER_PI_MODELS || path.join(PI_AGENT_HOME, "models.json");
-// omp (oh-my-pi) resolves its agent directory from `PI_CODING_AGENT_DIR`,
-// defaulting to `~/.oh-omp/agent`. `models.yml` is the modern format; the
-// legacy `models.json` is still read but is not what a current install writes.
+// omp (can1357/oh-my-pi) inherits pi's `PI_CODING_AGENT_DIR` override and
+// defaults to `~/.omp/agent`. It reads `models.yml`, then `models.yaml`, so an
+// existing `models.yaml` with no `models.yml` beside it is the document to edit:
+// creating a `models.yml` would silently shadow the user's file.
 export const OMP_AGENT_HOME =
-  process.env.PI_CODING_AGENT_DIR || path.join(os.homedir(), ".oh-omp", "agent");
+  process.env.PI_CODING_AGENT_DIR || path.join(os.homedir(), ".omp", "agent");
+const OMP_MODELS_YML = path.join(OMP_AGENT_HOME, "models.yml");
+const OMP_MODELS_YAML = path.join(OMP_AGENT_HOME, "models.yaml");
 export const OMP_MODELS_PATH =
-  process.env.MODEL_ROUTER_OMP_MODELS || path.join(OMP_AGENT_HOME, "models.yml");
+  process.env.MODEL_ROUTER_OMP_MODELS ||
+  (!existsSync(OMP_MODELS_YML) && existsSync(OMP_MODELS_YAML) ? OMP_MODELS_YAML : OMP_MODELS_YML);
 // Command Code keeps BYOK provider declarations in their own document, apart
 // from `auth.json` where its own credentials live. The router only ever writes
-// the former, and never a raw secret into it.
-export const COMMANDCODE_HOME =
-  process.env.COMMANDCODE_HOME || path.join(os.homedir(), ".commandcode");
+// the former, and never a raw secret into it. Command Code has no directory
+// override: it joins the home directory with `.commandcode`.
+export const COMMANDCODE_HOME = path.join(os.homedir(), ".commandcode");
 export const COMMANDCODE_PROVIDERS_PATH =
   process.env.MODEL_ROUTER_COMMANDCODE_PROVIDERS ||
   path.join(COMMANDCODE_HOME, "providers.json");

--- a/src/routed-harness-catalog.mjs
+++ b/src/routed-harness-catalog.mjs
@@ -68,6 +68,22 @@ export function routedHarnessDefaultModel(models) {
 // the router serves only the latter — so this is `@ai-sdk/openai` pointed at
 // the caller base URL, not the "compatible" package the phrase
 // "OpenAI-compatible endpoint" suggests.
+//
+// opencode's schema requires `output` beside `context` whenever `limit` is
+// present and rejects the whole document otherwise: opencode 1.18 refused every
+// model of a `{ context }`-only publish. The router has no per-model output cap
+// to report, but it does know where Codex compacts (`autoCompact`). opencode
+// compacts at `limit.input` less a small reserve when `input` is set, so
+// `input` is that threshold and `output` is the headroom the registry leaves
+// above it; opencode caps a single request at 32k either way. A model with no
+// usable threshold publishes no limit, which opencode reads as unknown.
+function opencodeLimit(model) {
+  const context = contextWindow(model);
+  const threshold = model.autoCompact;
+  if (!context || !Number.isInteger(threshold) || threshold <= 0 || threshold >= context) return undefined;
+  return { context, input: threshold, output: context - threshold };
+}
+
 function opencodeProvider({ models, baseUrl, secret }) {
   return {
     npm: "@ai-sdk/openai",
@@ -81,10 +97,10 @@ function opencodeProvider({ models, baseUrl, secret }) {
       apiKey: secret,
     },
     models: Object.fromEntries(models.map((model) => {
-      const context = contextWindow(model);
+      const limit = opencodeLimit(model);
       return [String(model.slug), {
         name: String(model.displayName || model.slug),
-        ...(context ? { limit: { context } } : {}),
+        ...(limit ? { limit } : {}),
       }];
     })),
   };
@@ -158,7 +174,9 @@ function ompProvider({ models, baseUrl }) {
 // the ids are `claude-model-id.mjs` ids and the base URL is the `/anthropic`
 // leaf. `apiKey: false` is Command Code's own spelling for a keyless endpoint —
 // and the only correct value here, because it refuses a pasted raw secret in
-// that field outright.
+// that field outright. Its loader reads `name`, `contextWindow`, and
+// `reasoningEfforts` per model; a model with no efforts is non-reasoning by
+// omission, so nothing else is written.
 const COMMANDCODE_EFFORTS = new Set(["low", "medium", "high", "xhigh", "max"]);
 
 function commandCodeProvider({ models, baseUrl }) {
@@ -173,7 +191,7 @@ function commandCodeProvider({ models, baseUrl }) {
       return [claudeModelId(model.slug), {
         name: String(model.displayName || model.slug),
         ...(context ? { contextWindow: context } : {}),
-        ...(reasoning.length ? { reasoningEfforts: reasoning } : { reasoning: false }),
+        ...(reasoning.length ? { reasoningEfforts: reasoning } : {}),
       }];
     })),
   };
@@ -259,18 +277,18 @@ const HARNESSES = Object.freeze([
     displayName: "omp",
     ownership: "omp",
     description: "The omp (oh-my-pi) terminal agent, publishing every model selected in this router.",
-    docsUrl: "https://github.com/open-horizon-labs/oh-omp/blob/main/docs/models.md",
-    siteUrl: "https://github.com/open-horizon-labs/oh-omp",
-    // The npm package installs `oh-omp`; the documented command is `omp`.
-    // Detect both rather than picking one and reporting a present client as
-    // missing on whichever install path the user took.
-    executables: Object.freeze(["omp", "oh-omp"]),
+    docsUrl: "https://github.com/can1357/oh-my-pi/blob/main/docs/models.md",
+    siteUrl: "https://omp.sh/",
+    // can1357/oh-my-pi, the project the `omp` command names. A fork published
+    // as `@oh-labs/oh-omp` installs an `oh-omp` binary that reads `~/.oh-omp`,
+    // so detecting both while writing into one home was wrong for the other.
+    executables: Object.freeze(["omp"]),
     binEnv: "OMP_BIN",
-    npmPackage: "@oh-labs/oh-omp@latest",
-    // The published package carries prebuilt binaries for darwin-arm64 and
-    // linux-x64 only. Offering to install it on anything else would hand the
-    // user an npm failure with no explanation in it.
-    installPlatforms: Object.freeze(["darwin", "linux"]),
+    // `@oh-my-pi/pi-coding-agent` runs on Bun (`#!/usr/bin/env bun`, engines
+    // `bun>=1.3.14`), so an `npm install -g` without Bun leaves an `omp` that
+    // cannot start. Its supported installs are a `curl | sh` script, Homebrew,
+    // and Bun itself, none of which this router runs on somebody's behalf.
+    npmPackage: undefined,
     format: "yaml",
     documentKey: "OMP_MODELS_PATH",
     providerPath: Object.freeze(["providers", ROUTED_HARNESS_PROVIDER_ID]),
@@ -295,6 +313,10 @@ const HARNESSES = Object.freeze([
     ),
     binEnv: "COMMANDCODE_BIN",
     npmPackage: "command-code@latest",
+    // `providers.json` BYOK support first shipped in 1.30.0; 1.29.0 and earlier
+    // never read the file, so publishing into an older CLI changes nothing it
+    // can see. Setup updates such a CLI, and status reports it.
+    minimumVersion: "1.30.0",
     format: "json",
     documentKey: "COMMANDCODE_PROVIDERS_PATH",
     providerPath: Object.freeze(["provider", ROUTED_HARNESS_PROVIDER_ID]),

--- a/src/routed-harness-catalog.mjs
+++ b/src/routed-harness-catalog.mjs
@@ -236,6 +236,11 @@ const HARNESSES = Object.freeze([
     executables: Object.freeze(["opencode"]),
     binEnv: "OPENCODE_BIN",
     npmPackage: "opencode-ai@latest",
+    // `opencode upgrade` knows how this copy was installed — npm, Homebrew, or
+    // the `curl | bash` script — and updates it in place. Reinstalling over an
+    // npm package that was never the live one leaves a second copy that may
+    // lose on PATH, so the client's own updater is preferred to `npm -g`.
+    updateCommand: Object.freeze(["upgrade"]),
     format: "json",
     documentKey: "OPENCODE_CONFIG_PATH",
     providerPath: Object.freeze(["provider", ROUTED_HARNESS_PROVIDER_ID]),
@@ -263,7 +268,15 @@ const HARNESSES = Object.freeze([
     siteUrl: "https://pi.dev/",
     executables: Object.freeze(["pi"]),
     binEnv: "PI_BIN",
-    npmPackage: "@mariozechner/pi-coding-agent@latest",
+    // pi moved publishers: `@mariozechner/pi-coding-agent` stopped at 0.73.1
+    // and the maintained line is `@earendil-works/pi-coding-agent`. Installing
+    // the old name pins a months-stale agent that still answers `pi --version`,
+    // so nothing here would report it as wrong.
+    npmPackage: "@earendil-works/pi-coding-agent@latest",
+    // pi's own quick start passes this: it needs no dependency lifecycle
+    // scripts, and running them is the failure mode on a locked-down machine.
+    npmInstallArgs: Object.freeze(["--ignore-scripts"]),
+    updateCommand: Object.freeze(["update", "--self"]),
     format: "json",
     documentKey: "PI_MODELS_PATH",
     providerPath: Object.freeze(["providers", ROUTED_HARNESS_PROVIDER_ID]),
@@ -289,6 +302,15 @@ const HARNESSES = Object.freeze([
     // cannot start. Its supported installs are a `curl | sh` script, Homebrew,
     // and Bun itself, none of which this router runs on somebody's behalf.
     npmPackage: undefined,
+    // omp ships no self-update subcommand, so there is nothing to run and
+    // nothing to install. The row prints the project's own three supported
+    // installs rather than guessing which one this copy came from.
+    updateCommand: undefined,
+    manualInstall: Object.freeze([
+      "curl -fsSL https://omp.sh/install | sh",
+      "brew install can1357/tap/omp",
+      "bun install -g @oh-my-pi/pi-coding-agent",
+    ]),
     format: "yaml",
     documentKey: "OMP_MODELS_PATH",
     providerPath: Object.freeze(["providers", ROUTED_HARNESS_PROVIDER_ID]),
@@ -313,6 +335,11 @@ const HARNESSES = Object.freeze([
     ),
     binEnv: "COMMANDCODE_BIN",
     npmPackage: "command-code@latest",
+    // Command Code updates itself in the background unless `--no-auto-update`
+    // is set, so a stale copy usually catches up on its own. `cmd update` is
+    // the supported way to force it now, and it stages the new build the same
+    // way the background path does.
+    updateCommand: Object.freeze(["update"]),
     // `providers.json` BYOK support first shipped in 1.30.0; 1.29.0 and earlier
     // never read the file, so publishing into an older CLI changes nothing it
     // can see. Setup updates such a CLI, and status reports it.
@@ -339,6 +366,13 @@ const HARNESSES = Object.freeze([
     // on a user's behalf, so the row asks them to install it and then
     // publishes into the client they already have.
     npmPackage: undefined,
+    // Hermes has no package to reinstall, but it does maintain itself: `hermes
+    // update` pulls its checkout and reinstalls its dependencies. `--yes` is
+    // what makes it non-interactive; it keeps its own pre-update backup.
+    updateCommand: Object.freeze(["update", "--yes"]),
+    manualInstall: Object.freeze([
+      "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash",
+    ]),
     format: "yaml",
     documentKey: "HERMES_CONFIG_PATH",
     providerPath: Object.freeze(["providers", ROUTED_HARNESS_PROVIDER_ID]),

--- a/src/routed-harness-catalog.mjs
+++ b/src/routed-harness-catalog.mjs
@@ -1,0 +1,351 @@
+// What each routed harness is told about the router, and where it is told it.
+//
+// Five clients — opencode, pi, omp, Command Code, and Hermes Agent — all offer
+// the same thing: a user-owned configuration document with a mapping of custom
+// providers in it. That similarity is why they share one publisher
+// (`routed-harness-manager.mjs`) instead of getting five near-identical
+// managers; this file is the part that genuinely differs, and it is data.
+//
+// Two rules shape every entry below.
+//
+// **The wire is one the router already serves.** The caller endpoint answers
+// `/v1/responses` and, behind the `/anthropic` leaf, the Anthropic Messages
+// API (`claude-surface.mjs`). Nothing else. A harness that speaks Responses is
+// pointed at the former; a harness that does not is pointed at the latter with
+// `claude-model-id.mjs` ids, because that surface exists precisely so a
+// non-Codex client can reach every routed model. No entry here invents a third
+// protocol and hopes.
+//
+// **The capability is the URL, not the key.** The caller secret is a path
+// segment (`caller-auth.mjs`), so a bearer is redundant: the request is already
+// authorized by the time a header is read. Where a harness treats a keyless
+// provider as first-class it is declared keyless; where a harness hides
+// keyless models from its own picker, the same secret is repeated in the field
+// it looks at. Both are noted per entry, because the difference is not
+// cosmetic — it decides whether the models show up at all.
+
+import { claudeModelId } from "./claude-model-id.mjs";
+
+/** The single key the router owns inside each client's provider mapping. */
+export const ROUTED_HARNESS_PROVIDER_ID = "codex-router";
+export const ROUTED_HARNESS_DISPLAY_NAME = "Codex Router";
+
+// The modalities the registry ever declares. Curated user models are
+// hand-edited state and may say anything, so every adapter filters.
+const MODALITIES = new Set(["text", "image"]);
+
+function inputModalities(model) {
+  const input = (model.inputModalities || ["text"]).map(String).filter((value) => MODALITIES.has(value));
+  return input.length ? input : ["text"];
+}
+
+function contextWindow(model) {
+  return Number.isInteger(model.contextWindow) && model.contextWindow > 0
+    ? model.contextWindow
+    : undefined;
+}
+
+function efforts(model, vocabulary) {
+  const levels = Array.isArray(model.reasoningLevels) ? model.reasoningLevels : [];
+  return [...new Set(levels.map((level) => String(level?.effort || "")).filter((effort) => vocabulary.has(effort)))];
+}
+
+/** The model a fresh session should start on: the highest priority routed one. */
+export function routedHarnessDefaultModel(models) {
+  return [...models].sort(
+    (left, right) =>
+      (right.priority ?? 0) - (left.priority ?? 0) ||
+      String(left.slug).localeCompare(String(right.slug)),
+  )[0];
+}
+
+// ---------------------------------------------------------------------------
+// opencode
+// ---------------------------------------------------------------------------
+
+// opencode resolves a provider to an AI SDK package. `@ai-sdk/openai-compatible`
+// is its Chat Completions client and `@ai-sdk/openai` its Responses client, and
+// the router serves only the latter — so this is `@ai-sdk/openai` pointed at
+// the caller base URL, not the "compatible" package the phrase
+// "OpenAI-compatible endpoint" suggests.
+function opencodeProvider({ models, baseUrl, secret }) {
+  return {
+    npm: "@ai-sdk/openai",
+    name: ROUTED_HARNESS_DISPLAY_NAME,
+    options: {
+      baseURL: baseUrl,
+      // opencode passes this straight to the SDK, which always sends a bearer.
+      // The path capability is what actually authorizes the call; repeating the
+      // secret here costs nothing and avoids an SDK that refuses to construct a
+      // client with no key at all.
+      apiKey: secret,
+    },
+    models: Object.fromEntries(models.map((model) => {
+      const context = contextWindow(model);
+      return [String(model.slug), {
+        name: String(model.displayName || model.slug),
+        ...(context ? { limit: { context } } : {}),
+      }];
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// pi
+// ---------------------------------------------------------------------------
+
+// pi loads `models.json` regardless of auth, but a provider with no resolvable
+// key leaves every model listed and unselectable in `/model`. So the secret is
+// repeated in `apiKey` with `authHeader` to send it. pi reads `$NAME` as an
+// environment variable and `!cmd` as a command; a caller secret matches
+// `[A-Za-z0-9_-]+` and can never begin with either, so it is always a literal.
+function piProvider({ models, baseUrl, secret }) {
+  return {
+    baseUrl,
+    api: "openai-responses",
+    apiKey: secret,
+    authHeader: true,
+    models: models.map((model) => {
+      const context = contextWindow(model);
+      return {
+        id: String(model.slug),
+        name: String(model.displayName || model.slug),
+        reasoning: efforts(model, PI_EFFORTS).length > 0,
+        input: inputModalities(model),
+        ...(context ? { contextWindow: context } : {}),
+      };
+    }),
+  };
+}
+
+const PI_EFFORTS = new Set(["low", "medium", "high"]);
+
+// ---------------------------------------------------------------------------
+// omp (oh-my-pi)
+// ---------------------------------------------------------------------------
+
+// omp validates a full custom provider as needing `baseUrl`, an `api`, and a
+// key *unless* `auth: none` — and it treats an `auth: none` provider as
+// available rather than hiding it, which is the one case in this file where a
+// harness's keyless path and its picker agree. So the secret stays in the URL
+// and nowhere else.
+const OMP_EFFORTS = new Set(["minimal", "low", "medium", "high", "xhigh", "max"]);
+
+function ompProvider({ models, baseUrl }) {
+  return {
+    baseUrl,
+    api: "openai-responses",
+    auth: "none",
+    models: models.map((model) => {
+      const context = contextWindow(model);
+      return {
+        id: String(model.slug),
+        name: String(model.displayName || model.slug),
+        reasoning: efforts(model, OMP_EFFORTS).length > 0,
+        input: inputModalities(model),
+        ...(context ? { contextWindow: context } : {}),
+      };
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Command Code
+// ---------------------------------------------------------------------------
+
+// Command Code's BYOK wire is Chat Completions or Anthropic Messages; it has no
+// Responses client. The router's Anthropic surface is the one it can reach, so
+// the ids are `claude-model-id.mjs` ids and the base URL is the `/anthropic`
+// leaf. `apiKey: false` is Command Code's own spelling for a keyless endpoint —
+// and the only correct value here, because it refuses a pasted raw secret in
+// that field outright.
+const COMMANDCODE_EFFORTS = new Set(["low", "medium", "high", "xhigh", "max"]);
+
+function commandCodeProvider({ models, baseUrl }) {
+  return {
+    name: ROUTED_HARNESS_DISPLAY_NAME,
+    api: "anthropic-messages",
+    baseURL: baseUrl,
+    apiKey: false,
+    models: Object.fromEntries(models.map((model) => {
+      const context = contextWindow(model);
+      const reasoning = efforts(model, COMMANDCODE_EFFORTS);
+      return [claudeModelId(model.slug), {
+        name: String(model.displayName || model.slug),
+        ...(context ? { contextWindow: context } : {}),
+        ...(reasoning.length ? { reasoningEfforts: reasoning } : { reasoning: false }),
+      }];
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hermes Agent
+// ---------------------------------------------------------------------------
+
+// Hermes names a custom endpoint's wire as `chat_completions`,
+// `anthropic_messages`, or `codex_responses`. `codex_responses` is its xAI
+// path rather than a generic Responses client, so this takes the Anthropic
+// surface for the same reason Command Code does. `discover_models: false`
+// matters: without it Hermes probes the endpoint's own catalog and would
+// replace the published list with whatever that probe returned.
+function hermesProvider({ models, baseUrl }) {
+  return {
+    name: ROUTED_HARNESS_DISPLAY_NAME,
+    api: baseUrl,
+    transport: "anthropic_messages",
+    discover_models: false,
+    models: Object.fromEntries(models.map((model) => {
+      const context = contextWindow(model);
+      return [claudeModelId(model.slug), context ? { context_length: context } : {}];
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The registry
+// ---------------------------------------------------------------------------
+
+const HARNESSES = Object.freeze([
+  Object.freeze({
+    id: "opencode",
+    displayName: "opencode",
+    ownership: "opencode",
+    description: "The opencode terminal agent, publishing every model selected in this router.",
+    docsUrl: "https://opencode.ai/docs/config/",
+    siteUrl: "https://opencode.ai/",
+    // `opencode-ai` declares one binary, named `opencode`, on every platform.
+    executables: Object.freeze(["opencode"]),
+    binEnv: "OPENCODE_BIN",
+    npmPackage: "opencode-ai@latest",
+    format: "json",
+    documentKey: "OPENCODE_CONFIG_PATH",
+    providerPath: Object.freeze(["provider", ROUTED_HARNESS_PROVIDER_ID]),
+    baseUrlPath: Object.freeze(["options", "baseURL"]),
+    // opencode also reads a JSONC sibling. This router re-serializes JSON and
+    // would delete the comments in one, so a document it cannot round-trip
+    // blocks publication with an explanation instead of being rewritten.
+    conflictSiblings: Object.freeze(["opencode.jsonc"]),
+    // The only harness here whose default-model key is a plain string in the
+    // same document. The others keep theirs in a second file or behind a
+    // mapping whose schema changes shape on first use, and guessing wrong there
+    // costs a user their configured model for no gain.
+    defaultModelPath: Object.freeze(["model"]),
+    defaultModelValue: (model) => `${ROUTED_HARNESS_PROVIDER_ID}/${model.slug}`,
+    wire: "responses",
+    buildProvider: opencodeProvider,
+    restartHint: "opencode reads its configuration when a session starts; the next `opencode` run picks this up.",
+  }),
+  Object.freeze({
+    id: "pi",
+    displayName: "pi",
+    ownership: "pi",
+    description: "Mario Zechner's pi coding agent, publishing every model selected in this router.",
+    docsUrl: "https://pi.dev/docs/latest/models",
+    siteUrl: "https://pi.dev/",
+    executables: Object.freeze(["pi"]),
+    binEnv: "PI_BIN",
+    npmPackage: "@mariozechner/pi-coding-agent@latest",
+    format: "json",
+    documentKey: "PI_MODELS_PATH",
+    providerPath: Object.freeze(["providers", ROUTED_HARNESS_PROVIDER_ID]),
+    baseUrlPath: Object.freeze(["baseUrl"]),
+    wire: "responses",
+    buildProvider: piProvider,
+    restartHint: "pi reads `models.json` at startup; the next `pi` run picks this up.",
+  }),
+  Object.freeze({
+    id: "omp",
+    displayName: "omp",
+    ownership: "omp",
+    description: "The omp (oh-my-pi) terminal agent, publishing every model selected in this router.",
+    docsUrl: "https://github.com/open-horizon-labs/oh-omp/blob/main/docs/models.md",
+    siteUrl: "https://github.com/open-horizon-labs/oh-omp",
+    // The npm package installs `oh-omp`; the documented command is `omp`.
+    // Detect both rather than picking one and reporting a present client as
+    // missing on whichever install path the user took.
+    executables: Object.freeze(["omp", "oh-omp"]),
+    binEnv: "OMP_BIN",
+    npmPackage: "@oh-labs/oh-omp@latest",
+    // The published package carries prebuilt binaries for darwin-arm64 and
+    // linux-x64 only. Offering to install it on anything else would hand the
+    // user an npm failure with no explanation in it.
+    installPlatforms: Object.freeze(["darwin", "linux"]),
+    format: "yaml",
+    documentKey: "OMP_MODELS_PATH",
+    providerPath: Object.freeze(["providers", ROUTED_HARNESS_PROVIDER_ID]),
+    baseUrlPath: Object.freeze(["baseUrl"]),
+    wire: "responses",
+    buildProvider: ompProvider,
+    restartHint: "omp reloads `models.yml` on its next run.",
+  }),
+  Object.freeze({
+    id: "commandcode",
+    displayName: "Command Code",
+    ownership: "commandcode",
+    description: "Command Code's CLI as a BYOK client of this router's Anthropic surface.",
+    docsUrl: "https://commandcode.ai/docs/byok",
+    siteUrl: "https://commandcode.ai/",
+    // `cmd` is taken by the Windows command shell, so Command Code ships as
+    // `cmdc` there. `command-code` is the full name and works everywhere.
+    executables: Object.freeze(
+      process.platform === "win32"
+        ? ["command-code", "cmdc"]
+        : ["command-code", "cmd"],
+    ),
+    binEnv: "COMMANDCODE_BIN",
+    npmPackage: "command-code@latest",
+    format: "json",
+    documentKey: "COMMANDCODE_PROVIDERS_PATH",
+    providerPath: Object.freeze(["provider", ROUTED_HARNESS_PROVIDER_ID]),
+    baseUrlPath: Object.freeze(["baseURL"]),
+    wire: "anthropic",
+    buildProvider: commandCodeProvider,
+    restartHint: "Command Code applies `providers.json` live; reopen `/model` to see the routed models.",
+  }),
+  Object.freeze({
+    id: "hermes",
+    displayName: "Hermes Agent",
+    ownership: "nousresearch",
+    description: "Nous Research's Hermes Agent as a named custom provider on this router.",
+    docsUrl: "https://hermes-agent.nousresearch.com/docs/integrations/providers",
+    siteUrl: "https://hermes-agent.nousresearch.com/",
+    executables: Object.freeze(["hermes"]),
+    binEnv: "HERMES_BIN",
+    // Hermes installs from its own shell script rather than a package
+    // registry. Running a remote installer is not something this router does
+    // on a user's behalf, so the row asks them to install it and then
+    // publishes into the client they already have.
+    npmPackage: undefined,
+    format: "yaml",
+    documentKey: "HERMES_CONFIG_PATH",
+    providerPath: Object.freeze(["providers", ROUTED_HARNESS_PROVIDER_ID]),
+    // Hermes names the endpoint `api`; `base_url` and `url` are accepted
+    // aliases, but the wizard writes `api`, so that is what ours writes too.
+    baseUrlPath: Object.freeze(["api"]),
+    wire: "anthropic",
+    buildProvider: hermesProvider,
+    restartHint: "Hermes reads `config.yaml` at startup; restart `hermes` (or its gateway) to pick this up.",
+  }),
+]);
+
+export const ROUTED_HARNESS_IDS = Object.freeze(HARNESSES.map((harness) => harness.id));
+
+/** One harness definition, or undefined for an id this router does not publish. */
+export function routedHarness(id) {
+  return HARNESSES.find((harness) => harness.id === String(id || ""));
+}
+
+/** Every harness definition, in the order the Harness tab lists them. */
+export function routedHarnesses() {
+  return HARNESSES;
+}
+
+/** The harness definition for `id`, or a thrown error naming the valid set. */
+export function assertRoutedHarness(id) {
+  const harness = routedHarness(id);
+  if (!harness) {
+    throw new Error(`Unknown routed harness "${id}". Expected one of: ${ROUTED_HARNESS_IDS.join(", ")}.`);
+  }
+  return harness;
+}

--- a/src/routed-harness-document.mjs
+++ b/src/routed-harness-document.mjs
@@ -224,12 +224,61 @@ export function renderYamlMapping(value, indent = "", lines = []) {
 }
 
 /** Returns the document text with `keyPath` replaced by `value`, as block YAML. */
+// Lines inside `node`'s indented region that none of its registered children
+// account for.
+//
+// Two separate blind spots make `children.size` an unsafe proxy for "this node
+// holds nothing but ours":
+//
+//   - `children` is the lexer's map of mapping keys it was able to register. A
+//     block sequence, a merge key, or a key `PLAIN_KEY` declines is invisible
+//     there while still living inside the node. This is how removal came to
+//     splice away a whole `providers:` sequence and leave a zero-byte file.
+//   - `endIndex` deliberately stops before a trailing comment block, so a
+//     comment the publish step pushed below our key sits outside the node's
+//     own range while still being spliced away with it.
+//
+// So the region is walked by indentation -- every following line that is blank
+// or indented deeper than the node -- rather than read off `endIndex`.
+function unaccountedLines(document, node) {
+  const covered = new Set();
+  for (const child of node.children.values()) {
+    for (let index = child.index; index <= child.endIndex; index += 1) covered.add(index);
+  }
+  const rest = [];
+  for (let index = node.index + 1; index < document.lines.length; index += 1) {
+    const text = String(document.lines[index] ?? "");
+    if (/^\s*$/.test(text)) continue;
+    const indent = text.length - text.replace(/^\s*/, "").length;
+    if (indent <= node.indent) break;
+    if (covered.has(index)) continue;
+    rest.push({ index, text });
+  }
+  return rest;
+}
+
 export function applyYamlValue(contents, keyPath, value) {
   const document = scanYamlDocument(contents);
   const parent = keyPath.length > 1 ? yamlNode(document, keyPath.slice(0, -1)) : undefined;
   if (parent?.inline) {
     throw new Error(
       `Refusing to edit ${keyPath.slice(0, -1).join(".")}: it is written as an inline value rather than a block.`,
+    );
+  }
+  // The mapping we are about to add a key to must be one the lexer read whole.
+  // If it holds a line no registered child accounts for, the shape on disk is
+  // not the shape `children` describes -- a block sequence, or a key such as
+  // `openrouter/free:` that the key grammar declines -- and splicing a mapping
+  // entry in either produces invalid YAML or nests our key inside the user's
+  // provider while every status read agrees it went in cleanly. Refuse with the
+  // file untouched, as the rest of this module does.
+  const unreadable = parent && unaccountedLines(document, parent).filter(
+    (line) => !/^\s*#/.test(line.text),
+  );
+  if (unreadable?.length) {
+    throw new Error(
+      `Refusing to edit ${keyPath.slice(0, -1).join(".")}: line ${unreadable[0].index + 1} `
+        + `(${unreadable[0].text.trim()}) is not a mapping entry this reader can account for.`,
     );
   }
   // Follow whatever indentation the document already uses for a sibling entry
@@ -264,6 +313,11 @@ export function removeYamlValue(contents, keyPath) {
   for (let depth = keyPath.length - 1; depth > 0; depth -= 1) {
     const parent = yamlNode(document, keyPath.slice(0, depth));
     if (!parent || parent.children.size !== 1) break;
+    // `children.size === 1` only says one *registered* key lives here. Stop if
+    // anything else does -- a sequence item, a merge key, a key the grammar
+    // declined, or the user's own comment. Leaving an empty `providers:` behind
+    // is a cosmetic cost; splicing the user's content away is not recoverable.
+    if (unaccountedLines(document, parent).length) break;
     removal = parent;
   }
   const lines = [...document.lines];

--- a/src/routed-harness-document.mjs
+++ b/src/routed-harness-document.mjs
@@ -1,0 +1,305 @@
+// Editing exactly one key of somebody else's configuration document.
+//
+// Every routed harness keeps its providers in a file the user also edits, and
+// that its own UI writes beside ours. So the rule these helpers exist to
+// enforce is the one `dsh-config-manager.mjs` states first: this router owns a
+// single key path and treats every other byte as somebody else's work.
+// Anything that cannot be read plainly is refused with the file untouched,
+// rather than reformatted into something we can read.
+//
+// Two document formats, because the clients chose differently:
+//
+//   json  opencode, pi, Command Code   parse, set one key, re-serialize
+//   yaml  omp, Hermes Agent            splice one block, leave the rest as text
+//
+// The JSON path round-trips through `JSON.parse`, which loses comments — so a
+// document that is not plain JSON is refused rather than silently stripped.
+// The YAML path never parses the file at all: it locates the router's block by
+// line range and replaces those lines, which is why a user's comments,
+// anchors, and hand-formatting survive a publish.
+
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { protectPrivateFile } from "./file-security.mjs";
+import { scanYamlDocument, spliceYamlBlock, yamlNode, yamlScalar } from "./yaml-structure.mjs";
+
+/** Reads a client's document, or "" when it does not exist yet. */
+export function readHarnessDocument(target) {
+  return existsSync(target) ? readFileSync(target, "utf8") : "";
+}
+
+/**
+ * Writes a client's document atomically, private to this user.
+ *
+ * Every document this module writes carries the caller base URL, and that URL
+ * *is* the local authentication capability — the secret is a path segment. So
+ * these files are 0600 under a 0700 directory whether or not the client would
+ * have created them that way itself.
+ */
+export function writeHarnessDocument(target, contents) {
+  mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
+  const temporary = `${target}.tmp.${process.pid}`;
+  writeFileSync(temporary, contents, { encoding: "utf8", mode: 0o600 });
+  try {
+    protectPrivateFile(temporary);
+    renameSync(temporary, target);
+    protectPrivateFile(target);
+  } catch (error) {
+    if (existsSync(temporary)) unlinkSync(temporary);
+    throw error;
+  }
+  return target;
+}
+
+// ---------------------------------------------------------------------------
+// JSON documents
+// ---------------------------------------------------------------------------
+
+function parseJsonDocument(contents, label) {
+  const text = String(contents ?? "").trim();
+  if (!text) return {};
+  let value;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    // JSONC is legal in several of these clients, and a `//` comment is the
+    // likeliest reason a real file lands here. Re-serializing would delete it,
+    // so say what is wrong and change nothing.
+    throw new Error(
+      `${label} is not plain JSON (comments and trailing commas cannot be preserved by this router); ` +
+        "fix or move it, then publish again.",
+    );
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} does not hold a JSON object; refusing to change client state.`);
+  }
+  return value;
+}
+
+function jsonAt(document, keyPath) {
+  let node = document;
+  for (const key of keyPath) {
+    if (!node || typeof node !== "object" || Array.isArray(node)) return undefined;
+    node = node[key];
+  }
+  return node;
+}
+
+function assertJsonContainers(document, keyPath, label) {
+  let node = document;
+  for (const key of keyPath.slice(0, -1)) {
+    const next = node[key];
+    if (next === undefined) return;
+    if (!next || typeof next !== "object" || Array.isArray(next)) {
+      throw new Error(
+        `${label} holds "${keyPath.slice(0, keyPath.indexOf(key) + 1).join(".")}" as something other ` +
+          "than an object; refusing to change client state.",
+      );
+    }
+    node = next;
+  }
+}
+
+/** The current value at `keyPath`, or undefined. Throws on an unreadable document. */
+export function jsonDocumentValue(contents, keyPath, label) {
+  return jsonAt(parseJsonDocument(contents, label), keyPath);
+}
+
+/** Returns the document text with `keyPath` set to `value`, creating parents. */
+export function applyJsonValue(contents, keyPath, value, label) {
+  const document = parseJsonDocument(contents, label);
+  assertJsonContainers(document, keyPath, label);
+  let node = document;
+  for (const key of keyPath.slice(0, -1)) {
+    if (!node[key] || typeof node[key] !== "object" || Array.isArray(node[key])) node[key] = {};
+    node = node[key];
+  }
+  node[keyPath.at(-1)] = value;
+  return `${JSON.stringify(document, null, 2)}\n`;
+}
+
+/**
+ * Returns the document text with `keyPath` removed.
+ *
+ * A container left holding nothing is removed with it, but only when this
+ * removal is what emptied it: a `provider: {}` the user wrote themselves is
+ * their file, not litter from ours.
+ */
+export function removeJsonValue(contents, keyPath, label) {
+  const document = parseJsonDocument(contents, label);
+  const chain = [document];
+  for (const key of keyPath.slice(0, -1)) {
+    const next = chain.at(-1)?.[key];
+    if (!next || typeof next !== "object" || Array.isArray(next)) {
+      return `${JSON.stringify(document, null, 2)}\n`;
+    }
+    chain.push(next);
+  }
+  delete chain.at(-1)[keyPath.at(-1)];
+  for (let depth = chain.length - 1; depth > 0; depth -= 1) {
+    if (Object.keys(chain[depth]).length) break;
+    delete chain[depth - 1][keyPath[depth - 1]];
+  }
+  return `${JSON.stringify(document, null, 2)}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// YAML documents
+// ---------------------------------------------------------------------------
+
+function joinLines(lines) {
+  const text = lines.join("\n");
+  return text.endsWith("\n") || text === "" ? text : `${text}\n`;
+}
+
+// Splitting on newlines yields a trailing empty element for the final newline,
+// and splicing beside it is how a document grows one blank line per write.
+// Leading blanks are the same story for a file that started empty.
+function normalizeTrailing(lines) {
+  const copy = [...lines];
+  while (copy.length > 1 && copy.at(-1) === "" && copy.at(-2) === "") copy.pop();
+  while (copy.length > 1 && copy[0] === "") copy.shift();
+  return copy;
+}
+
+// A mapping key that is a plain identifier can be written bare; anything else —
+// a routed slug carrying `/`, `.`, or `:` — is quoted. Getting this wrong is
+// not cosmetic: `codex_router/anthropic/x-ai/grok-4.6: {}` parses, but
+// `anthropic/claude: {}` inside a flow context does not, and a model id
+// beginning with a YAML indicator would silently become something else.
+function yamlKey(key) {
+  return /^[A-Za-z0-9_][A-Za-z0-9_.-]*$/.test(String(key)) ? String(key) : yamlScalar(key);
+}
+
+function yamlValueScalar(value) {
+  if (value === null) return "null";
+  if (typeof value === "number") return Number.isFinite(value) ? String(value) : yamlScalar(value);
+  if (typeof value === "boolean") return value ? "true" : "false";
+  return yamlScalar(value);
+}
+
+/**
+ * Renders a plain object as block YAML at `indent`.
+ *
+ * Only the shapes these adapters produce are covered: nested mappings, arrays
+ * of scalars, and arrays of flat mappings. `undefined` entries are dropped so a
+ * builder can omit a field by leaving it out rather than by branching.
+ */
+export function renderYamlMapping(value, indent = "", lines = []) {
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry === undefined) continue;
+    if (Array.isArray(entry)) {
+      if (!entry.length) {
+        lines.push(`${indent}${yamlKey(key)}: []`);
+        continue;
+      }
+      lines.push(`${indent}${yamlKey(key)}:`);
+      for (const item of entry) {
+        if (item && typeof item === "object") {
+          const nested = [];
+          renderYamlMapping(item, `${indent}    `, nested);
+          lines.push(`${indent}  - ${nested[0].trimStart()}`, ...nested.slice(1));
+        } else {
+          lines.push(`${indent}  - ${yamlValueScalar(item)}`);
+        }
+      }
+      continue;
+    }
+    if (entry && typeof entry === "object") {
+      // An empty mapping has to be written inline: a bare `key:` reads as null,
+      // and Hermes tells apart "this model has no declared options" from "this
+      // model is null" the same way every YAML reader does.
+      if (!Object.keys(entry).length) {
+        lines.push(`${indent}${yamlKey(key)}: {}`);
+        continue;
+      }
+      lines.push(`${indent}${yamlKey(key)}:`);
+      renderYamlMapping(entry, `${indent}  `, lines);
+      continue;
+    }
+    lines.push(`${indent}${yamlKey(key)}: ${yamlValueScalar(entry)}`);
+  }
+  return lines;
+}
+
+/** Returns the document text with `keyPath` replaced by `value`, as block YAML. */
+export function applyYamlValue(contents, keyPath, value) {
+  const document = scanYamlDocument(contents);
+  const parent = keyPath.length > 1 ? yamlNode(document, keyPath.slice(0, -1)) : undefined;
+  if (parent?.inline) {
+    throw new Error(
+      `Refusing to edit ${keyPath.slice(0, -1).join(".")}: it is written as an inline value rather than a block.`,
+    );
+  }
+  // Follow whatever indentation the document already uses for a sibling entry
+  // rather than assuming two spaces: a block indented differently from the ones
+  // beside it parses, but reads as though something went wrong.
+  const sibling = parent && [...parent.children.values()][0];
+  const indent = sibling
+    ? " ".repeat(sibling.indent)
+    : parent
+      ? " ".repeat(parent.indent + 2)
+      : "  ".repeat(keyPath.length - 1);
+  const leaf = yamlKey(keyPath.at(-1));
+  const rendered = value && typeof value === "object" && !Array.isArray(value)
+    ? [`${indent}${leaf}:`, ...renderYamlMapping(value, `${indent}  `, [])]
+    : [`${indent}${leaf}: ${yamlValueScalar(value)}`];
+  return joinLines(normalizeTrailing(spliceYamlBlock(document, keyPath, rendered)));
+}
+
+/**
+ * Returns the document text with `keyPath` removed.
+ *
+ * A parent mapping left holding nothing goes with it. An empty mapping is not
+ * the same as an absent one — a valueless key reads as null, not as "no
+ * providers" — and the only way one can be left behind is that publishing
+ * created it.
+ */
+export function removeYamlValue(contents, keyPath) {
+  const document = scanYamlDocument(contents);
+  const node = yamlNode(document, keyPath);
+  if (!node) return joinLines(normalizeTrailing(document.lines));
+  let removal = node;
+  for (let depth = keyPath.length - 1; depth > 0; depth -= 1) {
+    const parent = yamlNode(document, keyPath.slice(0, depth));
+    if (!parent || parent.children.size !== 1) break;
+    removal = parent;
+  }
+  const lines = [...document.lines];
+  lines.splice(removal.index, removal.endIndex - removal.index + 1);
+  return joinLines(normalizeTrailing(lines));
+}
+
+/** Whether a block exists at `keyPath`. */
+export function yamlValuePresent(contents, keyPath) {
+  return Boolean(yamlNode(scanYamlDocument(contents), keyPath));
+}
+
+/**
+ * Reads one scalar leaf out of a YAML document.
+ *
+ * Deliberately not a parse: the router only ever needs to answer "is the base
+ * URL under this key one we issued", and reading a single `key: value` line is
+ * the whole of that question. Anything that is not a plain scalar on one line
+ * reads as absent, which is the safe answer — an unrecognized base URL is
+ * treated as somebody else's provider and left alone.
+ */
+export function yamlLeafScalar(contents, keyPath) {
+  const document = scanYamlDocument(contents);
+  const node = yamlNode(document, keyPath);
+  if (!node || node.index < 0 || node.endIndex !== node.index) return undefined;
+  const line = document.lines[node.index];
+  const match = String(line).match(/^\s*(?:"(?:[^"\\]|\\.)*"|'(?:[^']|'')*'|[^:]+):\s*(.*?)\s*$/);
+  const raw = match?.[1];
+  if (!raw) return undefined;
+  if (raw.startsWith('"')) {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return undefined;
+    }
+  }
+  if (raw.startsWith("'")) return raw.slice(1, -1).replaceAll("''", "'");
+  return raw.startsWith("#") ? undefined : raw;
+}

--- a/src/routed-harness-install.mjs
+++ b/src/routed-harness-install.mjs
@@ -1,0 +1,160 @@
+// Finding and installing the five routed harness CLIs.
+//
+// The discipline is the one `dsh-install.mjs` set, and it is repeated here
+// rather than assumed: installing a third-party package over the network is
+// something a user asked for in as many words, never a consequence of
+// something else. Nothing in this file runs from `apply`, `enable`, or a
+// repair path — only from the explicit setup action on that client's row.
+//
+// The npm mechanics themselves live in `npm-global-install.mjs`, one copy for
+// this and for the provider CLIs, because the details that took a debugging
+// session to get right (the PATH a spawn inherits, where npm drops binaries
+// per platform, which line of npm's output is worth showing) are exactly what
+// drifts between copies.
+//
+// Hermes Agent has no package-registry install: it ships a shell script the
+// user pipes into their shell. This router does not run remote installers on
+// somebody's behalf, so that row reports the CLI as missing and links to the
+// official instructions instead of offering a button that does it.
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  npmGlobalBinary,
+  npmInstallGlobal,
+  spawnEnvironment,
+} from "./npm-global-install.mjs";
+import { assertRoutedHarness, routedHarnesses } from "./routed-harness-catalog.mjs";
+import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
+
+const INSTALL_TIMEOUT_MS = 10 * 60_000;
+const VERSION_TIMEOUT_MS = 20_000;
+
+/**
+ * Where this harness's CLI is, or undefined.
+ *
+ * An explicit `<HARNESS>_BIN` wins so a desktop app — which does not inherit
+ * the login shell's PATH — can hand over the executable it already validated
+ * rather than asking a narrower child to rediscover it. Otherwise PATH, then
+ * npm's global bin directory, which is where a just-installed package lands on
+ * a machine whose PATH has not been reloaded yet.
+ */
+export function routedHarnessCliPath(id, { environment = process.env } = {}) {
+  const harness = assertRoutedHarness(id);
+  const configured = harness.binEnv ? environment[harness.binEnv] : undefined;
+  if (configured && existsSync(configured)) return configured;
+  for (const executable of harness.executables) {
+    const found = commandOnPath(executable) || npmGlobalBinary(executable);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+/** The version string this CLI reports, or undefined when it will not say. */
+export function routedHarnessVersion(id, binary = routedHarnessCliPath(id)) {
+  if (!binary) return undefined;
+  try {
+    const command = spawnableCommand(binary, ["--version"]);
+    const output = execFileSync(command.command, command.args, {
+      ...command.options,
+      encoding: "utf8",
+      env: spawnEnvironment(),
+      timeout: VERSION_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    });
+    return String(output || "")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => /\d+\.\d+/.test(line)) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Whether this router can install this harness itself on this platform. */
+export function routedHarnessInstallable(id, { platform = process.platform } = {}) {
+  const harness = assertRoutedHarness(id);
+  if (!harness.npmPackage) return false;
+  return !harness.installPlatforms || harness.installPlatforms.includes(platform);
+}
+
+/** Detection only: never installs, never writes, safe to call on page load. */
+export function routedHarnessSnapshot(id, { environment = process.env } = {}) {
+  const harness = assertRoutedHarness(id);
+  const binary = routedHarnessCliPath(id, { environment });
+  return {
+    id: harness.id,
+    displayName: harness.displayName,
+    package: harness.npmPackage || null,
+    installable: routedHarnessInstallable(id),
+    installed: Boolean(binary),
+    binary: binary || null,
+    version: routedHarnessVersion(id, binary) || null,
+  };
+}
+
+/**
+ * Installs the harness CLI globally when it is missing.
+ *
+ * Global, not `npx`: an `npx` process refetches per run, leaves no executable
+ * behind, and is invisible to `presence-state.mjs`, which has to be able to see
+ * a client to keep the router up for it.
+ */
+export function installRoutedHarness(id, {
+  force = false,
+  find = routedHarnessCliPath,
+  install = npmInstallGlobal,
+  platform = process.platform,
+} = {}) {
+  const harness = assertRoutedHarness(id);
+  const existing = find(id);
+  if (existing && !force) return { installed: true, binary: existing, changed: false };
+  if (!harness.npmPackage) {
+    throw new Error(
+      `${harness.displayName} is not installed and does not publish a package this router can install. ` +
+        `Install it from ${harness.siteUrl}, then publish again.`,
+    );
+  }
+  if (!routedHarnessInstallable(id, { platform })) {
+    throw new Error(
+      `${harness.displayName} publishes no build for ${platform}. Install it yourself from ` +
+        `${harness.siteUrl} if it supports this platform, then publish again.`,
+    );
+  }
+  install(harness.npmPackage, { label: harness.displayName, timeoutMs: INSTALL_TIMEOUT_MS });
+  const binary = find(id);
+  if (!binary) {
+    throw new Error(
+      `npm installed ${harness.npmPackage}, but no \`${harness.executables[0]}\` was found on PATH ` +
+        "or in npm's global bin directory.",
+    );
+  }
+  return { installed: true, binary, changed: true };
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [, , command = "status", id] = process.argv;
+  try {
+    if (command === "status" && !id) {
+      process.stdout.write(
+        `${JSON.stringify(routedHarnesses().map((harness) => routedHarnessSnapshot(harness.id)), null, 2)}\n`,
+      );
+    } else if (command === "status") {
+      process.stdout.write(`${JSON.stringify(routedHarnessSnapshot(id), null, 2)}\n`);
+    } else if (command === "install" && id) {
+      process.stdout.write(
+        `${JSON.stringify(installRoutedHarness(id, { force: process.argv.includes("--force") }), null, 2)}\n`,
+      );
+    } else {
+      console.error("Usage: routed-harness-install status [HARNESS]|install HARNESS [--force]");
+      process.exit(2);
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/src/routed-harness-install.mjs
+++ b/src/routed-harness-install.mjs
@@ -101,6 +101,18 @@ export function routedHarnessInstallable(id) {
   return Boolean(assertRoutedHarness(id).npmPackage);
 }
 
+/**
+ * Whether this router can move this harness to its latest release.
+ *
+ * Broader than `routedHarnessInstallable`: Hermes has no package to reinstall
+ * but does maintain its own checkout, so it can be updated without ever having
+ * been installable from here.
+ */
+export function routedHarnessUpdatable(id) {
+  const harness = assertRoutedHarness(id);
+  return Boolean(harness.updateCommand || harness.npmPackage);
+}
+
 /** Detection only: never installs, never writes, safe to call on page load. */
 export function routedHarnessSnapshot(id, { environment = process.env } = {}) {
   const harness = assertRoutedHarness(id);
@@ -116,6 +128,15 @@ export function routedHarnessSnapshot(id, { environment = process.env } = {}) {
     version,
     minimumVersion: harness.minimumVersion || null,
     outdated: routedHarnessOutdated(id, version),
+    updatable: routedHarnessUpdatable(id),
+    // What an update would actually run, so a row can say so before it is
+    // clicked and a support bundle records it afterwards.
+    updateVia: harness.updateCommand
+      ? `${harness.executables[0]} ${harness.updateCommand.join(" ")}`
+      : harness.npmPackage
+        ? `npm install -g ${harness.npmPackage}`
+        : null,
+    manualInstall: harness.manualInstall ? [...harness.manualInstall] : null,
   };
 }
 
@@ -143,7 +164,11 @@ export function installRoutedHarness(id, {
         `Install it from ${harness.siteUrl}, then publish again.`,
     );
   }
-  install(harness.npmPackage, { label: harness.displayName, timeoutMs: INSTALL_TIMEOUT_MS });
+  install(harness.npmPackage, {
+    label: harness.displayName,
+    timeoutMs: INSTALL_TIMEOUT_MS,
+    ...(harness.npmInstallArgs ? { extraArgs: [...harness.npmInstallArgs] } : {}),
+  });
   const binary = find(id);
   if (!binary) {
     throw new Error(
@@ -161,6 +186,74 @@ export function installRoutedHarness(id, {
   return { installed: true, binary, changed: true, ...(outdated ? { upgraded: true } : {}) };
 }
 
+/**
+ * Moves one harness CLI to its latest release.
+ *
+ * Prefers the client's *own* updater over `npm install -g`. A CLI installed by
+ * Homebrew or a `curl | sh` script is not an npm package, and reinstalling it
+ * as one leaves two copies whose winner is decided by PATH order — the class of
+ * bug where the row reports the new version and the shell keeps running the old
+ * one. `opencode upgrade`, `pi update --self`, `cmd update`, and `hermes
+ * update` each know how their own copy was installed; npm is the fallback for a
+ * client that publishes a package but ships no updater.
+ *
+ * Like installing, this is never a side effect of publishing: it runs only from
+ * `control client-update` and the Harness row's own button.
+ */
+export function updateRoutedHarness(id, {
+  find = routedHarnessCliPath,
+  version = routedHarnessVersion,
+  install = npmInstallGlobal,
+  run = execFileSync,
+} = {}) {
+  const harness = assertRoutedHarness(id);
+  const binary = find(id);
+  const from = binary ? version(id, binary) || null : null;
+
+  if (binary && harness.updateCommand) {
+    const command = spawnableCommand(binary, [...harness.updateCommand]);
+    try {
+      run(command.command, command.args, {
+        ...command.options,
+        encoding: "utf8",
+        env: spawnEnvironment(),
+        timeout: INSTALL_TIMEOUT_MS,
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
+    } catch (error) {
+      const detail = String(error?.stderr || error?.stdout || error?.message || "").trim();
+      throw new Error(
+        `\`${harness.executables[0]} ${harness.updateCommand.join(" ")}\` failed.${detail ? ` ${detail.slice(-2_000)}` : ""}`,
+      );
+    }
+  } else if (harness.npmPackage) {
+    install(harness.npmPackage, {
+      label: harness.displayName,
+      timeoutMs: INSTALL_TIMEOUT_MS,
+      ...(harness.npmInstallArgs ? { extraArgs: [...harness.npmInstallArgs] } : {}),
+    });
+  } else {
+    throw new Error(
+      `${harness.displayName} has no updater this router can run. Update it with: ` +
+        `${(harness.manualInstall || [harness.siteUrl]).join("  |  ")}`,
+    );
+  }
+
+  const updated = find(id);
+  const to = updated ? version(id, updated) || null : null;
+  return {
+    harness: harness.id,
+    binary: updated || null,
+    from,
+    to,
+    // A client that reports no version at all cannot be said to have changed.
+    // Saying "updated" on that evidence is the claim this router must not make.
+    changed: Boolean(from && to && from !== to),
+    versionReported: Boolean(to),
+  };
+}
+
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const [, , command = "status", id] = process.argv;
   try {
@@ -174,8 +267,10 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
       process.stdout.write(
         `${JSON.stringify(installRoutedHarness(id, { force: process.argv.includes("--force") }), null, 2)}\n`,
       );
+    } else if (command === "update" && id) {
+      process.stdout.write(`${JSON.stringify(updateRoutedHarness(id), null, 2)}\n`);
     } else {
-      console.error("Usage: routed-harness-install status [HARNESS]|install HARNESS [--force]");
+      console.error("Usage: routed-harness-install status [HARNESS]|install HARNESS [--force]|update HARNESS");
       process.exit(2);
     }
   } catch (error) {

--- a/src/routed-harness-install.mjs
+++ b/src/routed-harness-install.mjs
@@ -12,10 +12,11 @@
 // per platform, which line of npm's output is worth showing) are exactly what
 // drifts between copies.
 //
-// Hermes Agent has no package-registry install: it ships a shell script the
-// user pipes into their shell. This router does not run remote installers on
-// somebody's behalf, so that row reports the CLI as missing and links to the
-// official instructions instead of offering a button that does it.
+// Hermes Agent and omp have no install this router can run: Hermes ships a
+// shell script the user pipes into their shell, and omp runs on Bun and
+// installs from its own script, Homebrew, or Bun. This router does not run
+// remote installers on somebody's behalf, so those rows report the CLI as
+// missing and link to the official instructions instead of offering a button.
 
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
@@ -75,17 +76,36 @@ export function routedHarnessVersion(id, binary = routedHarnessCliPath(id)) {
   }
 }
 
-/** Whether this router can install this harness itself on this platform. */
-export function routedHarnessInstallable(id, { platform = process.platform } = {}) {
-  const harness = assertRoutedHarness(id);
-  if (!harness.npmPackage) return false;
-  return !harness.installPlatforms || harness.installPlatforms.includes(platform);
+function versionParts(value) {
+  const match = String(value || "").match(/(\d+)\.(\d+)\.(\d+)/);
+  return match ? match.slice(1).map(Number) : undefined;
+}
+
+/**
+ * Whether this CLI reports a version below the one that reads what the router
+ * publishes. A version the CLI will not report is not called outdated: that is
+ * an unknown, and refusing a working client over it would be the worse error.
+ */
+export function routedHarnessOutdated(id, version) {
+  const minimum = versionParts(assertRoutedHarness(id).minimumVersion);
+  const actual = versionParts(version);
+  if (!minimum || !actual) return false;
+  for (let index = 0; index < minimum.length; index += 1) {
+    if (actual[index] !== minimum[index]) return actual[index] < minimum[index];
+  }
+  return false;
+}
+
+/** Whether this router can install this harness itself. */
+export function routedHarnessInstallable(id) {
+  return Boolean(assertRoutedHarness(id).npmPackage);
 }
 
 /** Detection only: never installs, never writes, safe to call on page load. */
 export function routedHarnessSnapshot(id, { environment = process.env } = {}) {
   const harness = assertRoutedHarness(id);
   const binary = routedHarnessCliPath(id, { environment });
+  const version = routedHarnessVersion(id, binary) || null;
   return {
     id: harness.id,
     displayName: harness.displayName,
@@ -93,12 +113,15 @@ export function routedHarnessSnapshot(id, { environment = process.env } = {}) {
     installable: routedHarnessInstallable(id),
     installed: Boolean(binary),
     binary: binary || null,
-    version: routedHarnessVersion(id, binary) || null,
+    version,
+    minimumVersion: harness.minimumVersion || null,
+    outdated: routedHarnessOutdated(id, version),
   };
 }
 
 /**
- * Installs the harness CLI globally when it is missing.
+ * Installs the harness CLI globally when it is missing, and updates one too old
+ * to read the document the router publishes into.
  *
  * Global, not `npx`: an `npx` process refetches per run, leaves no executable
  * behind, and is invisible to `presence-state.mjs`, which has to be able to see
@@ -107,22 +130,17 @@ export function routedHarnessSnapshot(id, { environment = process.env } = {}) {
 export function installRoutedHarness(id, {
   force = false,
   find = routedHarnessCliPath,
+  version = routedHarnessVersion,
   install = npmInstallGlobal,
-  platform = process.platform,
 } = {}) {
   const harness = assertRoutedHarness(id);
   const existing = find(id);
-  if (existing && !force) return { installed: true, binary: existing, changed: false };
+  const outdated = Boolean(existing && harness.minimumVersion) && routedHarnessOutdated(id, version(id, existing));
+  if (existing && !force && !outdated) return { installed: true, binary: existing, changed: false };
   if (!harness.npmPackage) {
     throw new Error(
       `${harness.displayName} is not installed and does not publish a package this router can install. ` +
         `Install it from ${harness.siteUrl}, then publish again.`,
-    );
-  }
-  if (!routedHarnessInstallable(id, { platform })) {
-    throw new Error(
-      `${harness.displayName} publishes no build for ${platform}. Install it yourself from ` +
-        `${harness.siteUrl} if it supports this platform, then publish again.`,
     );
   }
   install(harness.npmPackage, { label: harness.displayName, timeoutMs: INSTALL_TIMEOUT_MS });
@@ -133,7 +151,14 @@ export function installRoutedHarness(id, {
         "or in npm's global bin directory.",
     );
   }
-  return { installed: true, binary, changed: true };
+  if (harness.minimumVersion && routedHarnessOutdated(id, version(id, binary))) {
+    // npm updated its copy, but an older install elsewhere still wins on PATH.
+    throw new Error(
+      `${harness.displayName} at ${binary} is still older than ${harness.minimumVersion}, the first release ` +
+        "that reads the provider this router publishes. Update or remove that install, then publish again.",
+    );
+  }
+  return { installed: true, binary, changed: true, ...(outdated ? { upgraded: true } : {}) };
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/src/routed-harness-manager.mjs
+++ b/src/routed-harness-manager.mjs
@@ -1,0 +1,487 @@
+// Publishing the routed catalog into one of the five document-configured
+// harnesses, and taking it back out again.
+//
+// One publisher, five clients. The rules it enforces are the ones every other
+// client integration in this repository already follows, and they are worth
+// restating because each of them was a bug first:
+//
+// - **The marker is the installed-ness, not the client's file.** A snapshot in
+//   the router's own state directory records what this router last wrote. Drift
+//   is measured against it rather than by re-deriving what "should" be there
+//   and trusting the answer, and it survives a user who edits or moves the
+//   client's document by hand.
+// - **A provider we did not write is never replaced or removed.** A
+//   `codex-router` entry whose base URL is not one this router issued belongs
+//   to somebody else — a second checkout, an older build, a hand-written proxy
+//   — and both install and uninstall refuse rather than guess.
+// - **The default model is the user's.** Only opencode has a default key this
+//   integration touches at all, and only while it is one this router wrote or
+//   the user has not chosen anything.
+// - **A failed publish leaves the client where it was.** The document is
+//   captured before the write and restored if the marker cannot be recorded, so
+//   a client is never left pointed at a route the router has no record of.
+
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+
+import {
+  assertCallerSecret,
+  callerBaseUrl,
+  claudeBaseUrl,
+  isManagedCallerBaseUrl,
+  isManagedClaudeBaseUrl,
+  redactCallerUrl,
+} from "./caller-auth.mjs";
+import { privateFileIsProtected, writePrivateJson } from "./file-security.mjs";
+import * as PATHS from "./paths.mjs";
+import { CALLER_SECRET_PATH, LEGACY_PORTS, PORTS, ROUTED_HARNESS_CATALOG_PATHS } from "./paths.mjs";
+import {
+  ROUTED_HARNESS_PROVIDER_ID,
+  assertRoutedHarness,
+  routedHarnessDefaultModel,
+  routedHarnesses,
+} from "./routed-harness-catalog.mjs";
+import {
+  applyJsonValue,
+  applyYamlValue,
+  jsonDocumentValue,
+  readHarnessDocument as readDocumentFile,
+  removeJsonValue,
+  removeYamlValue,
+  writeHarnessDocument,
+  yamlLeafScalar,
+  yamlValuePresent,
+} from "./routed-harness-document.mjs";
+import { routedHarnessCliPath, installRoutedHarness } from "./routed-harness-install.mjs";
+import { routedClientModels } from "./routed-client-models.mjs";
+import { assertStateOwnership } from "./state-owner.mjs";
+
+/** The user-owned document this harness's providers live in. */
+export function harnessDocumentPath(harness) {
+  const target = PATHS[harness.documentKey];
+  if (!target) throw new Error(`No configured document path for ${harness.displayName}.`);
+  return target;
+}
+
+function currentSecret(secretPath = CALLER_SECRET_PATH) {
+  if (!existsSync(secretPath)) {
+    throw new Error("The local router caller key is missing; run ./bin/doctor --fix.");
+  }
+  return assertCallerSecret(readFileSync(secretPath, "utf8").trim());
+}
+
+function redactFailure(value, secret) {
+  const redacted = redactCallerUrl(String(value ?? ""));
+  return secret ? redacted.replaceAll(String(secret), "[REDACTED]") : redacted;
+}
+
+/** The router endpoint this harness's wire reaches. */
+export function harnessBaseUrl(harness, secret, port = PORTS.router) {
+  return harness.wire === "anthropic" ? claudeBaseUrl(port, secret) : callerBaseUrl(port, secret);
+}
+
+function baseUrlManaged(harness, value, port = PORTS.router, legacyPort = LEGACY_PORTS.router) {
+  const check = harness.wire === "anthropic" ? isManagedClaudeBaseUrl : isManagedCallerBaseUrl;
+  if (!value) return false;
+  return check(value, port) || (legacyPort !== undefined && check(value, legacyPort));
+}
+
+/** A sibling document this router cannot round-trip, if the client keeps one. */
+function conflictingSibling(harness, documentPath) {
+  for (const sibling of harness.conflictSiblings || []) {
+    const target = path.join(path.dirname(documentPath), sibling);
+    if (existsSync(target)) return target;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Reading what is currently published
+// ---------------------------------------------------------------------------
+
+/**
+ * The base URL of the provider currently sitting under our key, or undefined.
+ *
+ * JSON documents are parsed; YAML documents are read one scalar line at a time
+ * (`yamlLeafScalar`) rather than parsed, because "is this URL one we issued" is
+ * the whole of the question and a real parser would be a second, divergent
+ * understanding of a file this router only ever splices.
+ */
+export function publishedBaseUrl(harness, contents) {
+  const label = harness.displayName;
+  if (harness.format === "json") {
+    const provider = jsonDocumentValue(contents, harness.providerPath, label);
+    if (!provider || typeof provider !== "object") return undefined;
+    let node = provider;
+    for (const key of harness.baseUrlPath) {
+      if (!node || typeof node !== "object") return undefined;
+      node = node[key];
+    }
+    return typeof node === "string" ? node : undefined;
+  }
+  return yamlLeafScalar(contents, [...harness.providerPath, ...harness.baseUrlPath]);
+}
+
+/** Whether our key is present at all, in either format. */
+export function providerPresent(harness, contents) {
+  return harness.format === "json"
+    ? jsonDocumentValue(contents, harness.providerPath, harness.displayName) !== undefined
+    : yamlValuePresent(contents, harness.providerPath);
+}
+
+// ---------------------------------------------------------------------------
+// The publication marker
+// ---------------------------------------------------------------------------
+
+function markerPath(harness) {
+  const target = ROUTED_HARNESS_CATALOG_PATHS[harness.id];
+  if (!target) throw new Error(`No publication marker configured for ${harness.displayName}.`);
+  return target;
+}
+
+function readMarker(harness, port = PORTS.router, legacyPort = LEGACY_PORTS.router) {
+  const target = markerPath(harness);
+  if (!existsSync(target)) return undefined;
+  let state;
+  try {
+    state = JSON.parse(readFileSync(target, "utf8"));
+  } catch {
+    throw new Error(
+      `The ${harness.displayName} router publication marker is not valid JSON; refusing to change client state.`,
+    );
+  }
+  const objectState = Boolean(state && typeof state === "object" && !Array.isArray(state));
+  const defaultValid = objectState && state.defaultOwned === true
+    ? typeof state.defaultModel === "string" && state.defaultModel.length > 0
+    : objectState && state.defaultOwned === false && state.defaultModel === null;
+  const valid = objectState &&
+    state.version === 1 &&
+    state.harness === harness.id &&
+    state.provider === ROUTED_HARNESS_PROVIDER_ID &&
+    typeof state.baseUrl === "string" && baseUrlManaged(harness, state.baseUrl, port, legacyPort) &&
+    Array.isArray(state.models) && state.models.length > 0 &&
+    state.models.every((model) => typeof model === "string" && model.length > 0) &&
+    new Set(state.models).size === state.models.length &&
+    (state.visionBridgeEngine === null || typeof state.visionBridgeEngine === "string") &&
+    defaultValid &&
+    typeof state.updatedAt === "string" && Number.isFinite(Date.parse(state.updatedAt));
+  if (!valid) {
+    throw new Error(
+      `The ${harness.displayName} router publication marker has an unsupported or malformed shape; ` +
+        "refusing to change client state.",
+    );
+  }
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Editing the client's document
+// ---------------------------------------------------------------------------
+
+function withProvider(harness, contents, provider) {
+  return harness.format === "json"
+    ? applyJsonValue(contents, harness.providerPath, provider, harness.displayName)
+    : applyYamlValue(contents, harness.providerPath, provider);
+}
+
+function withoutProvider(harness, contents) {
+  return harness.format === "json"
+    ? removeJsonValue(contents, harness.providerPath, harness.displayName)
+    : removeYamlValue(contents, harness.providerPath);
+}
+
+function readDefaultModel(harness, contents) {
+  if (!harness.defaultModelPath) return undefined;
+  const value = harness.format === "json"
+    ? jsonDocumentValue(contents, harness.defaultModelPath, harness.displayName)
+    : yamlLeafScalar(contents, harness.defaultModelPath);
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function withDefaultModel(harness, contents, value) {
+  return harness.format === "json"
+    ? applyJsonValue(contents, harness.defaultModelPath, value, harness.displayName)
+    : applyYamlValue(contents, harness.defaultModelPath, value);
+}
+
+function withoutDefaultModel(harness, contents) {
+  return harness.format === "json"
+    ? removeJsonValue(contents, harness.defaultModelPath, harness.displayName)
+    : removeYamlValue(contents, harness.defaultModelPath);
+}
+
+// ---------------------------------------------------------------------------
+// The manager
+// ---------------------------------------------------------------------------
+
+export function createRoutedHarnessManager(id, {
+  documentPath,
+  markerFile,
+  secretPath = CALLER_SECRET_PATH,
+  port = PORTS.router,
+  legacyPort = LEGACY_PORTS.router,
+  modelSource = routedClientModels,
+  assertOwnership = assertStateOwnership,
+  findCli = routedHarnessCliPath,
+  installCli = installRoutedHarness,
+  readDocument = readDocumentFile,
+  writeDocument = writeHarnessDocument,
+  writeMarker = writePrivateJson,
+} = {}) {
+  const harness = assertRoutedHarness(id);
+  const document = () => documentPath || harnessDocumentPath(harness);
+  const marker = () => markerFile || markerPath(harness);
+
+  function assertPublishable(contents, state) {
+    const conflict = conflictingSibling(harness, document());
+    if (conflict) {
+      throw new Error(
+        `${harness.displayName} also has ${conflict}, which this router cannot rewrite without ` +
+          "discarding its comments. Consolidate the two documents, then publish again.",
+      );
+    }
+    if (!providerPresent(harness, contents)) return;
+    const existing = publishedBaseUrl(harness, contents);
+    if (!state && !baseUrlManaged(harness, existing, port, legacyPort)) {
+      throw new Error(
+        `${harness.displayName} already has an unmanaged ${ROUTED_HARNESS_PROVIDER_ID} provider; ` +
+          "rename or remove it before setup.",
+      );
+    }
+    if (!baseUrlManaged(harness, existing, port, legacyPort)) {
+      throw new Error(
+        `Refusing to replace a ${harness.displayName} provider whose base URL is not managed by this router.`,
+      );
+    }
+  }
+
+  function install({ installMissingCli = false } = {}) {
+    assertOwnership(`write the ${harness.displayName} model catalog`);
+    const { models, engine } = modelSource();
+    if (!models.length) {
+      throw new Error(
+        "No routed models are selected, credentialed, and listed. Enable a provider first " +
+          "(`./bin/providers enable PROVIDER`), then publish again.",
+      );
+    }
+    if (installMissingCli && !findCli(harness.id)) installCli(harness.id);
+
+    const target = document();
+    const state = readMarker(harness, port, legacyPort);
+    const before = readDocument(target);
+    assertPublishable(before, state);
+
+    const secret = currentSecret(secretPath);
+    const baseUrl = harnessBaseUrl(harness, secret, port);
+    const provider = harness.buildProvider({ models, baseUrl, secret });
+
+    // The default model is the user's own choice. Take it over only when this
+    // router already owned the value that is there, or when there is no value
+    // at all — a snapshot taken before somebody picked their own model is not a
+    // licence to undo that pick.
+    const currentDefault = readDefaultModel(harness, before);
+    const desiredDefault = harness.defaultModelPath
+      ? harness.defaultModelValue(routedHarnessDefaultModel(models))
+      : undefined;
+    const previouslyOwned = Boolean(
+      state?.defaultOwned && state.defaultModel && currentDefault === state.defaultModel,
+    );
+    const defaultOwned = Boolean(desiredDefault) && (previouslyOwned || (!state && !currentDefault));
+
+    let after = withProvider(harness, before, provider);
+    if (defaultOwned) after = withDefaultModel(harness, after, desiredDefault);
+
+    writeDocument(target, after);
+    try {
+      writeMarker(marker(), {
+        version: 1,
+        harness: harness.id,
+        provider: ROUTED_HARNESS_PROVIDER_ID,
+        baseUrl,
+        document: target,
+        models: models.map((model) => String(model.slug)),
+        visionBridgeEngine: engine?.slug || null,
+        defaultOwned,
+        defaultModel: defaultOwned ? desiredDefault : null,
+        updatedAt: new Date().toISOString(),
+      }, { directoryMode: 0o700 });
+    } catch (error) {
+      // The client is now pointed at a route the router has no record of, which
+      // is the one state neither uninstall nor drift detection can reason
+      // about. Put the document back exactly as it was found.
+      try {
+        writeDocument(target, before);
+      } catch (rollbackError) {
+        throw new Error(
+          `${redactFailure(error instanceof Error ? error.message : error, secret)} ` +
+            `${harness.displayName} rollback also failed: ` +
+            `${redactFailure(rollbackError instanceof Error ? rollbackError.message : rollbackError, secret)}`,
+        );
+      }
+      throw new Error(redactFailure(error instanceof Error ? error.message : error, secret));
+    }
+
+    return {
+      harness: harness.id,
+      provider: ROUTED_HARNESS_PROVIDER_ID,
+      document: target,
+      models: models.length,
+      visionBridgeEngine: engine?.slug || null,
+      defaultOwned,
+      defaultModel: defaultOwned ? desiredDefault : null,
+      restartHint: harness.restartHint,
+    };
+  }
+
+  function uninstall() {
+    assertOwnership(`remove the ${harness.displayName} integration`);
+    const target = document();
+    const state = readMarker(harness, port, legacyPort);
+    const before = readDocument(target);
+    const present = before ? providerPresent(harness, before) : false;
+
+    if (!state) {
+      if (present) {
+        throw new Error(
+          `Refusing to remove an unmanaged ${harness.displayName} ${ROUTED_HARNESS_PROVIDER_ID} provider.`,
+        );
+      }
+      return { removed: false, harness: harness.id, provider: ROUTED_HARNESS_PROVIDER_ID };
+    }
+    if (present && !baseUrlManaged(harness, publishedBaseUrl(harness, before), port, legacyPort)) {
+      throw new Error(
+        `Refusing to remove a ${harness.displayName} provider whose base URL is not managed by this router.`,
+      );
+    }
+
+    let after = before;
+    // Leaving the client pointed at a provider this uninstall just deleted is
+    // worse than leaving it with no default, so a default we own is removed
+    // rather than left dangling. One the user has since changed is theirs.
+    const defaultRemoved = Boolean(
+      state.defaultOwned && state.defaultModel &&
+        readDefaultModel(harness, before) === state.defaultModel,
+    );
+    if (defaultRemoved) after = withoutDefaultModel(harness, after);
+    if (present) after = withoutProvider(harness, after);
+    if (after !== before) writeDocument(target, after);
+    if (existsSync(marker())) unlinkSync(marker());
+    return { removed: present, harness: harness.id, provider: ROUTED_HARNESS_PROVIDER_ID, defaultRemoved };
+  }
+
+  function status() {
+    const { models } = modelSource();
+    const target = document();
+    const cli = findCli(harness.id);
+    const base = {
+      harness: harness.id,
+      displayName: harness.displayName,
+      document: target,
+      documentExists: existsSync(target),
+      cliInstalled: Boolean(cli),
+      ...(cli ? { cli } : {}),
+      routableModels: models.length,
+    };
+    let state;
+    try {
+      state = readMarker(harness, port, legacyPort);
+    } catch (error) {
+      return {
+        ...base,
+        installed: existsSync(marker()),
+        stateValid: false,
+        providerInstalled: false,
+        configValid: false,
+        configError: redactFailure(error instanceof Error ? error.message : error),
+        publishedModels: 0,
+        catalogFresh: false,
+      };
+    }
+    try {
+      const contents = readDocument(target);
+      const present = contents ? providerPresent(harness, contents) : false;
+      const liveBaseUrl = present ? publishedBaseUrl(harness, contents) : undefined;
+      const secret = currentSecret(secretPath);
+      const expectedBaseUrl = harnessBaseUrl(harness, secret, port);
+      const expectedProvider = harness.buildProvider({ models, baseUrl: expectedBaseUrl, secret });
+      // JSON documents round-trip, so the published provider can be compared
+      // whole. YAML ones are spliced as text and never parsed back, so the
+      // comparable evidence there is the marker plus the live base URL.
+      const providerValid = harness.format === "json"
+        ? isDeepStrictEqual(jsonDocumentValue(contents, harness.providerPath, harness.displayName), expectedProvider)
+        : present && liveBaseUrl === expectedBaseUrl;
+      const markerFresh = Boolean(state) && state.baseUrl === expectedBaseUrl &&
+        isDeepStrictEqual(state.models, models.map((model) => String(model.slug)));
+      return {
+        ...base,
+        installed: Boolean(state),
+        stateValid: true,
+        provider: ROUTED_HARNESS_PROVIDER_ID,
+        providerInstalled: present,
+        baseUrlManaged: baseUrlManaged(harness, liveBaseUrl, port, legacyPort),
+        callerCapabilityCurrent: liveBaseUrl === expectedBaseUrl,
+        baseUrl: liveBaseUrl ? redactCallerUrl(liveBaseUrl) : null,
+        documentProtected: Boolean(base.documentExists && privateFileIsProtected(target)),
+        configValid: providerValid,
+        ...(present && !providerValid
+          ? {
+            configError:
+                `the live ${harness.displayName} provider differs from the router-owned protocol, ` +
+                "models, or caller capability",
+          }
+          : {}),
+        publishedModels: state?.models?.length ?? 0,
+        catalogFresh: markerFresh && providerValid,
+        defaultOwned: Boolean(state?.defaultOwned),
+        defaultModel: harness.defaultModelPath ? (readDefaultModel(harness, contents) || null) : null,
+      };
+    } catch (error) {
+      return {
+        ...base,
+        installed: Boolean(state),
+        providerInstalled: false,
+        configValid: false,
+        configError: redactFailure(error instanceof Error ? error.message : error),
+        publishedModels: state?.models?.length ?? 0,
+        catalogFresh: false,
+      };
+    }
+  }
+
+  // Rotating the caller key changes the base URL, which is the capability
+  // itself. Republishing is the whole of the fix, so it is the same call.
+  return { harness, install, uninstall, status, refreshCallerCapability: () => install() };
+}
+
+/** Every routed harness with a publication marker on disk. */
+export function installedRoutedHarnesses() {
+  return routedHarnesses()
+    .filter((harness) => existsSync(ROUTED_HARNESS_CATALOG_PATHS[harness.id]))
+    .map((harness) => harness.id);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [, , id, command = "status", ...rest] = process.argv;
+  try {
+    const manager = createRoutedHarnessManager(id);
+    const handlers = {
+      install: () => manager.install({ installMissingCli: rest.includes("--install-cli") }),
+      uninstall: manager.uninstall,
+      status: manager.status,
+      "caller-capability-refresh": manager.refreshCallerCapability,
+    };
+    const handler = handlers[command];
+    if (!handler) {
+      console.error(
+        `Usage: routed-harness-manager HARNESS ${Object.keys(handlers).join("|")} [--install-cli]`,
+      );
+      process.exit(2);
+    }
+    process.stdout.write(`${JSON.stringify(handler(), null, 2)}\n`);
+  } catch (error) {
+    console.error(redactFailure(error instanceof Error ? error.message : error));
+    process.exit(1);
+  }
+}

--- a/src/routed-harness-manager.mjs
+++ b/src/routed-harness-manager.mjs
@@ -54,7 +54,12 @@ import {
   yamlLeafScalar,
   yamlValuePresent,
 } from "./routed-harness-document.mjs";
-import { routedHarnessCliPath, installRoutedHarness } from "./routed-harness-install.mjs";
+import {
+  installRoutedHarness,
+  routedHarnessCliPath,
+  routedHarnessOutdated,
+  routedHarnessVersion,
+} from "./routed-harness-install.mjs";
 import { routedClientModels } from "./routed-client-models.mjs";
 import { assertStateOwnership } from "./state-owner.mjs";
 
@@ -141,8 +146,10 @@ function markerPath(harness) {
   return target;
 }
 
-function readMarker(harness, port = PORTS.router, legacyPort = LEGACY_PORTS.router) {
-  const target = markerPath(harness);
+// The path is a parameter because the manager accepts an injected marker file:
+// reading the state directory's copy while writing the injected one made a
+// publish look stale and an uninstall look unmanaged.
+function readMarker(harness, target = markerPath(harness), port = PORTS.router, legacyPort = LEGACY_PORTS.router) {
   if (!existsSync(target)) return undefined;
   let state;
   try {
@@ -225,6 +232,7 @@ export function createRoutedHarnessManager(id, {
   modelSource = routedClientModels,
   assertOwnership = assertStateOwnership,
   findCli = routedHarnessCliPath,
+  cliVersion = routedHarnessVersion,
   installCli = installRoutedHarness,
   readDocument = readDocumentFile,
   writeDocument = writeHarnessDocument,
@@ -266,10 +274,12 @@ export function createRoutedHarnessManager(id, {
           "(`./bin/providers enable PROVIDER`), then publish again.",
       );
     }
-    if (installMissingCli && !findCli(harness.id)) installCli(harness.id);
+    // The installer decides: it returns at once for a present, current CLI and
+    // updates one too old to read the document published below.
+    if (installMissingCli) installCli(harness.id);
 
     const target = document();
-    const state = readMarker(harness, port, legacyPort);
+    const state = readMarker(harness, marker(), port, legacyPort);
     const before = readDocument(target);
     assertPublishable(before, state);
 
@@ -338,7 +348,7 @@ export function createRoutedHarnessManager(id, {
   function uninstall() {
     assertOwnership(`remove the ${harness.displayName} integration`);
     const target = document();
-    const state = readMarker(harness, port, legacyPort);
+    const state = readMarker(harness, marker(), port, legacyPort);
     const before = readDocument(target);
     const present = before ? providerPresent(harness, before) : false;
 
@@ -375,6 +385,8 @@ export function createRoutedHarnessManager(id, {
     const { models } = modelSource();
     const target = document();
     const cli = findCli(harness.id);
+    // Only a client with a minimum costs a `--version` spawn here.
+    const version = cli && harness.minimumVersion ? cliVersion(harness.id, cli) : undefined;
     const base = {
       harness: harness.id,
       displayName: harness.displayName,
@@ -382,11 +394,14 @@ export function createRoutedHarnessManager(id, {
       documentExists: existsSync(target),
       cliInstalled: Boolean(cli),
       ...(cli ? { cli } : {}),
+      ...(version ? { cliVersion: version } : {}),
+      ...(harness.minimumVersion ? { cliMinimumVersion: harness.minimumVersion } : {}),
+      cliOutdated: routedHarnessOutdated(harness.id, version),
       routableModels: models.length,
     };
     let state;
     try {
-      state = readMarker(harness, port, legacyPort);
+      state = readMarker(harness, marker(), port, legacyPort);
     } catch (error) {
       return {
         ...base,

--- a/src/routed-harness-manager.mjs
+++ b/src/routed-harness-manager.mjs
@@ -280,6 +280,7 @@ export function createRoutedHarnessManager(id, {
 
     const target = document();
     const state = readMarker(harness, marker(), port, legacyPort);
+    const documentExisted = existsSync(target);
     const before = readDocument(target);
     assertPublishable(before, state);
 
@@ -322,7 +323,11 @@ export function createRoutedHarnessManager(id, {
       // is the one state neither uninstall nor drift detection can reason
       // about. Put the document back exactly as it was found.
       try {
-        writeDocument(target, before);
+        // "Back" for a client that had no document is absent, not empty: a
+        // zero-byte opencode.json or models.json is not valid JSON, which is
+        // worse for the client than the absence this path exists to restore.
+        if (documentExisted) writeDocument(target, before);
+        else if (existsSync(target)) unlinkSync(target);
       } catch (rollbackError) {
         throw new Error(
           `${redactFailure(error instanceof Error ? error.message : error, secret)} ` +

--- a/src/target-integration.mjs
+++ b/src/target-integration.mjs
@@ -12,9 +12,11 @@ import {
   GEMINI_CATALOG_PATH,
   OPENCLAW_CATALOG_PATH,
   NATIVE_CATALOG_PATH,
+  ROUTED_HARNESS_CATALOG_PATHS,
   SOURCE_ROOT,
   TARGET,
 } from "./paths.mjs";
+import { routedHarnesses } from "./routed-harness-catalog.mjs";
 
 // The begin markers config-manager.mjs writes around every block it owns,
 // including the legacy kimi-era pairs it still recognizes. config-manager.mjs
@@ -168,6 +170,15 @@ export function installedTargets() {
   if (existsSync(CURSOR_CATALOG_PATH)) installed.push("cursor");
   if (existsSync(CLAUDE_CATALOG_PATH)) installed.push("claude");
   if (existsSync(OPENCLAW_CATALOG_PATH)) installed.push("openclaw");
+  // The document-configured harnesses (opencode, pi, omp, Command Code,
+  // Hermes) are published clients like any other, so a live publication keeps
+  // the shared plane alive for them too. They are not `MODEL_ROUTER_TARGET`
+  // values -- nothing installs *as* one of them -- but `bin/disable` retires
+  // the service only once this list is empty, and forgetting them here is how
+  // turning Codex off would stop opencode working.
+  for (const harness of routedHarnesses()) {
+    if (existsSync(ROUTED_HARNESS_CATALOG_PATHS[harness.id])) installed.push(harness.id);
+  }
   return installed;
 }
 
@@ -255,6 +266,19 @@ export async function refreshTargetPickerIfInstalled({ signal, deadline } = {}) 
   }
   if (existsSync(OPENCLAW_CATALOG_PATH)) {
     await runTargetPublicationProcess("openclaw-config-manager.mjs", ["install"], {
+      signal,
+      deadline: operationDeadline,
+    });
+    refreshed = true;
+  }
+  // Same rule for the five document-configured harnesses: the marker in the
+  // router's own state directory says this router published there, so a
+  // provider being enabled, a key being stored, or a model being curated
+  // republishes each of them rather than leaving one picker advertising a
+  // model the others just lost.
+  for (const harness of routedHarnesses()) {
+    if (!existsSync(ROUTED_HARNESS_CATALOG_PATHS[harness.id])) continue;
+    await runTargetPublicationProcess("routed-harness-manager.mjs", [harness.id, "install"], {
       signal,
       deadline: operationDeadline,
     });

--- a/test/control-center-electron.test.mjs
+++ b/test/control-center-electron.test.mjs
@@ -1846,7 +1846,30 @@ test("control center focus feedback uses state changes without focus rings", asy
 
 test("harness and context IPC remain fixed and session-scoped", async () => {
   const source = await readFile(new URL("../apps/control-center/electron/ipc.mjs", import.meta.url), "utf8");
-  assert.match(source, /const HARNESS_IDS = \["codex", "dsh", "gemini", "cursor", "claude", "openclaw"\]/);
+  assert.match(
+    source,
+    /const HARNESS_IDS = \["codex", "dsh", "gemini", "cursor", "claude", "openclaw", \.\.\.ROUTED_HARNESS_IDS\]/,
+  );
+  // The document-configured rows are a fixed table, not a discovered one: the
+  // app must be able to draw the Harness tab before it can load a module out
+  // of the installed router, so their ids, markers, and executables are pinned
+  // here the same way every other client surface is.
+  assert.match(source, /const ROUTED_HARNESS_IDS = ROUTED_HARNESS_ROWS\.map\(\(row\) => row\.id\)/);
+  for (const [id, marker] of [
+    ["opencode", "opencode-models.json"],
+    ["pi", "pi-models.json"],
+    ["omp", "omp-models.json"],
+    ["commandcode", "commandcode-models.json"],
+    ["hermes", "hermes-models.json"],
+  ]) {
+    assert.match(source, new RegExp(`id: "${id}",`));
+    assert.match(source, new RegExp(`marker: "${marker}"`));
+  }
+  // Hermes installs from a remote shell script. Offering to run that on the
+  // user's behalf is exactly what this router does not do.
+  assert.match(source, /id: "hermes",[\s\S]*?installable: false/);
+  assert.match(source, /existsSync\(path\.join\(stateDirectory, row\.marker\)\)/);
+  assert.match(source, /environmentOverrides\[routedSetup\.binEnv\] = binary/);
   assert.match(source, /const HARNESS_SURFACES = \["app", "terminal"\]/);
   assert.match(source, /const SESSION_UUID = \/\^\[0-9a-f\]/);
   assert.match(source, /const DSH_SESSION_ID = \/\^session-/);
@@ -1942,7 +1965,17 @@ test("Harness page renders fixed client rows backed by the shared session index"
     "utf8",
   );
 
-  assert.match(harness, /const CLIENT_ORDER: HarnessId\[\] = \["openclaw", "cursor", "claude", "gemini", "dsh", "codex"\]/);
+  assert.match(
+    harness,
+    /const CLIENT_ORDER: HarnessId\[\] = \[\s*"openclaw", "cursor", "claude", "gemini", "dsh", "codex",\s*"opencode", "pi", "omp", "commandcode", "hermes",\s*\]/,
+  );
+  // The pre-existing six keep their positions so an upgrade does not move a
+  // user's rows out from under them.
+  assert.ok(
+    harness.indexOf('"openclaw", "cursor", "claude", "gemini", "dsh", "codex",')
+      < harness.indexOf('"opencode", "pi", "omp", "commandcode", "hermes",'),
+  );
+  assert.match(harness, /const TERMINAL_ONLY_CLIENTS = new Set<HarnessId>\(\["opencode", "pi", "omp", "commandcode", "hermes"\]\)/);
   assert.match(harness, /api\.getContextSessions\(\)/);
   assert.match(harness, /api\.getAgentBridges\(\)/);
   assert.match(harness, /Official-client agent/);
@@ -1953,7 +1986,13 @@ test("Harness page renders fixed client rows backed by the shared session index"
   assert.match(harness, /Connect Cursor/);
   assert.match(harness, /One guided setup/);
   assert.match(harness, /Cursor setup progress/);
-  assert.match(harness, /api\.launchHarness\(harness\.id, "app"\)/);
+  // A routed harness has no desktop app, so its Open action must reach a
+  // terminal rather than falling through to the client's marketing site.
+  assert.match(
+    harness,
+    /const surface = TERMINAL_ONLY_CLIENTS\.has\(harness\.id\) && harness\.cliInstalled \? "terminal" : "app"/,
+  );
+  assert.match(harness, /api\.launchHarness\(harness\.id, surface\)/);
   assert.match(harness, /<AppWindow[^>]*\/> Open/);
   assert.doesNotMatch(harness, /BookOpen|SquareTerminal|Open agent/);
   assert.doesNotMatch(harness, /Stable public HTTPS origin|127\.0\.0\.1:4214/);

--- a/test/control-center-harness.test.mjs
+++ b/test/control-center-harness.test.mjs
@@ -77,7 +77,12 @@ test("context manager reads bounded metadata without returning conversation mess
     process.env.CODEX_ROUTER_CURSOR_AGENT_CHATS = cursorAgentChats;
     const snapshot = getContextSessionsSnapshot();
 
-    assert.deepEqual(snapshot.counts, { total: 4, codex: 1, dsh: 1, cursor: 2, claude: 0, gemini: 0, openclaw: 0, archived: 0 });
+    // The five document-configured harnesses write no session index this app
+    // can read, so their rows must report zero rather than an invented number.
+    assert.deepEqual(snapshot.counts, {
+      total: 4, codex: 1, dsh: 1, cursor: 2, claude: 0, gemini: 0, openclaw: 0,
+      opencode: 0, pi: 0, omp: 0, commandcode: 0, hermes: 0, archived: 0,
+    });
     assert.equal(snapshot.sessions.find((session) => session.id === CODEX_ID)?.model, "deepseek/deepseek-v4-pro");
     assert.equal(snapshot.sessions.find((session) => session.id === DSH_ID)?.workspaceLabel, "DeepSeek workspace");
     assert.equal(snapshot.sessions.find((session) => session.id === CURSOR_ID)?.title, "Cursor session");
@@ -218,9 +223,18 @@ test("health IPC reads in-process and preserves the injected fetch boundary", as
   assert.doesNotMatch(source, /handle\("getHealth"[\s\S]{0,100}runJson\(\["health"\]\)/);
 });
 
-test("client setup is fixed to the six supported targets and keeps session bodies unread", async () => {
+test("client setup is fixed to the supported targets and keeps session bodies unread", async () => {
   const source = await readFile(new URL("../apps/control-center/electron/ipc.mjs", import.meta.url), "utf8");
-  assert.match(source, /const HARNESS_IDS = \["codex", "dsh", "gemini", "cursor", "claude", "openclaw"\]/);
+  assert.match(
+    source,
+    /const HARNESS_IDS = \["codex", "dsh", "gemini", "cursor", "claude", "openclaw", \.\.\.ROUTED_HARNESS_IDS\]/,
+  );
+  // The routed rows are a fixed table too, not a discovered one.
+  assert.match(source, /const ROUTED_HARNESS_IDS = ROUTED_HARNESS_ROWS\.map\(\(row\) => row\.id\)/);
+  assert.deepEqual(
+    [...source.matchAll(/^    id: "([a-z-]+)",$/gm)].map((match) => match[1]),
+    ["opencode", "pi", "omp", "commandcode", "hermes"],
+  );
   assert.match(source, /const args = \["client-setup", harness\]/);
   assert.match(source, /Cursor public URL/);
   assert.match(source, /cursorConnectorRunner\(installer\.executable, installer\.args/);

--- a/test/openai-adapters.test.mjs
+++ b/test/openai-adapters.test.mjs
@@ -207,6 +207,17 @@ test("Responses stream drops a keep-alive after the terminal event instead of fa
   assert.equal(output.some((frame) => frame.event === "error"), false);
 });
 
+test("a stream of nothing but keep-alives still reports an incomplete stream", async () => {
+  // Comments are not forwarded, but they are proof the upstream was talking.
+  // Swallowing them silently would turn a stream that died before its terminal
+  // event into an empty, error-free turn.
+  const output = frames(await transformText(createResponsesStreamTransform(), [
+    ": keep-alive\n\n",
+  ]));
+  assert.equal(output.at(-1).event, "error");
+  assert.equal(output.at(-1).data.code, "upstream_stream_incomplete");
+});
+
 test("Responses provider errors stay structured and do not gain a second terminal frame", async () => {
   const output = frames(await transformText(createResponsesStreamTransform(), [
     "event: error\ndata: {\"type\":\"error\",\"code\":\"provider_failed\",\"message\":\"upstream rejected\"}\n\n",

--- a/test/openai-adapters.test.mjs
+++ b/test/openai-adapters.test.mjs
@@ -188,6 +188,25 @@ test("Responses stream rejects unknown, conflicting, and post-terminal tool indi
   assert.match(afterTerminal.at(-1).data.message, /after its terminal/);
 });
 
+test("Responses stream drops a keep-alive after the terminal event instead of failing the turn", async () => {
+  // OpenCode Go and Zen send exactly this `ping` after every response.completed.
+  // Turning it into an error appended a gateway failure to completed turns,
+  // which strict Responses clients (opencode's AI SDK, pi) reject.
+  const output = frames(await transformText(createResponsesStreamTransform(), [
+    "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-6\"}}\n\n",
+    ": keep-alive\n\n",
+    "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-6\",\"status\":\"completed\"}}\n\n",
+    "event: ping\ndata: {\"type\":\"ping\",\"cost\":\"0\"}\n\n",
+    ": trailing comment\n\n",
+    "data: [DONE]\n\n",
+  ]));
+  assert.deepEqual(
+    output.map((frame) => frame.data?.type ?? frame.data),
+    ["response.created", "response.completed", "[DONE]"],
+  );
+  assert.equal(output.some((frame) => frame.event === "error"), false);
+});
+
 test("Responses provider errors stay structured and do not gain a second terminal frame", async () => {
   const output = frames(await transformText(createResponsesStreamTransform(), [
     "event: error\ndata: {\"type\":\"error\",\"code\":\"provider_failed\",\"message\":\"upstream rejected\"}\n\n",

--- a/test/routed-harness.test.mjs
+++ b/test/routed-harness.test.mjs
@@ -1,0 +1,369 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+// `paths.mjs` resolves every document location once, at import time, so the
+// redirection has to be in place before the first import of anything that
+// reaches it. Nothing in this file may touch a real client's home.
+const root = mkdtempSync(path.join(os.tmpdir(), "routed-harness-test-"));
+const stateDir = path.join(root, "state");
+mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+const SECRET = "c".repeat(48);
+writeFileSync(path.join(stateDir, "caller-secret"), `${SECRET}\n`, { mode: 0o600 });
+
+const DOCUMENTS = Object.freeze({
+  opencode: path.join(root, "opencode", "opencode.json"),
+  pi: path.join(root, "pi", "models.json"),
+  omp: path.join(root, "omp", "models.yml"),
+  commandcode: path.join(root, "commandcode", "providers.json"),
+  hermes: path.join(root, "hermes", "config.yaml"),
+});
+
+process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+process.env.MODEL_ROUTER_OPENCODE_CONFIG = DOCUMENTS.opencode;
+process.env.MODEL_ROUTER_PI_MODELS = DOCUMENTS.pi;
+process.env.MODEL_ROUTER_OMP_MODELS = DOCUMENTS.omp;
+process.env.MODEL_ROUTER_COMMANDCODE_PROVIDERS = DOCUMENTS.commandcode;
+process.env.MODEL_ROUTER_HERMES_CONFIG = DOCUMENTS.hermes;
+
+const { ROUTED_HARNESS_IDS, routedHarness, routedHarnesses } = await import(
+  "../src/routed-harness-catalog.mjs"
+);
+const { createRoutedHarnessManager } = await import("../src/routed-harness-manager.mjs");
+const { routedHarnessInstallable } = await import("../src/routed-harness-install.mjs");
+const { applyYamlValue, removeYamlValue, yamlLeafScalar } = await import(
+  "../src/routed-harness-document.mjs"
+);
+const { ROUTED_HARNESS_CATALOG_PATHS } = await import("../src/paths.mjs");
+
+const MODELS = [
+  {
+    slug: "moonshot/kimi-k3",
+    displayName: "Kimi K3",
+    contextWindow: 262_144,
+    inputModalities: ["text"],
+    reasoningLevels: [{ effort: "low" }, { effort: "high" }],
+    priority: 10,
+  },
+  {
+    slug: "x-ai/grok-4.6",
+    displayName: "Grok 4.6",
+    contextWindow: 2_000_000,
+    inputModalities: ["text", "image"],
+    reasoningLevels: [],
+    priority: 5,
+  },
+];
+
+function manager(id, overrides = {}) {
+  return createRoutedHarnessManager(id, {
+    modelSource: () => ({ models: MODELS, engine: null }),
+    // Detection is not what these tests are about, and a machine that happens
+    // to have one of these CLIs installed must not change the result.
+    findCli: () => "/nonexistent/bin/harness",
+    ...overrides,
+  });
+}
+
+function reset() {
+  for (const target of Object.values(DOCUMENTS)) rmSync(path.dirname(target), { recursive: true, force: true });
+  for (const id of ROUTED_HARNESS_IDS) rmSync(path.join(stateDir, `${id}-models.json`), { force: true });
+}
+
+test("every routed harness publishes the whole routed catalog and takes it back out", () => {
+  for (const harness of routedHarnesses()) {
+    reset();
+    const client = manager(harness.id);
+    const result = client.install();
+    assert.equal(result.harness, harness.id);
+    assert.equal(result.models, MODELS.length);
+
+    const published = readFileSync(DOCUMENTS[harness.id], "utf8");
+    // Every model reaches every client. The id differs by wire -- the
+    // Anthropic surface takes prefixed ids -- but the *set* never does.
+    for (const model of MODELS) assert.match(published, new RegExp(model.slug.replaceAll(".", "\\.")));
+
+    const status = client.status();
+    assert.equal(status.installed, true);
+    assert.equal(status.providerInstalled, true);
+    assert.equal(status.baseUrlManaged, true);
+    assert.equal(status.configValid, true, `${harness.id}: ${status.configError || ""}`);
+    assert.equal(status.catalogFresh, true);
+    assert.equal(status.publishedModels, MODELS.length);
+    // The caller secret is a path segment of the base URL, so status output --
+    // which reaches doctor and support bundles -- must never carry it.
+    assert.doesNotMatch(JSON.stringify(status), new RegExp(SECRET));
+
+    const removed = client.uninstall();
+    assert.equal(removed.removed, true);
+    assert.doesNotMatch(readFileSync(DOCUMENTS[harness.id], "utf8"), /codex-router/);
+    assert.equal(existsSync(path.join(stateDir, `${harness.id}-models.json`)), false);
+  }
+});
+
+test("each harness is pointed at a wire the router actually serves", () => {
+  reset();
+  for (const harness of routedHarnesses()) {
+    manager(harness.id).install();
+    const published = readFileSync(DOCUMENTS[harness.id], "utf8");
+    if (harness.wire === "anthropic") {
+      // The Anthropic surface is reached at the `/anthropic` leaf with
+      // `claude-model-id.mjs` ids; a bare slug there would 404 on a model the
+      // surface never published.
+      assert.match(published, /_codex-router\/[^"\s]+\/anthropic/);
+      assert.match(published, /codex_router\/anthropic\/moonshot\/kimi-k3/);
+    } else {
+      assert.match(published, /_codex-router\/[^"\s]+\/v1/);
+      assert.match(published, /openai-responses|@ai-sdk\/openai/);
+    }
+    // Chat Completions is the one OpenAI-compatible wire the caller endpoint
+    // does not answer, so no adapter may ever declare it.
+    assert.doesNotMatch(published, /openai-completions|openai-compatible/);
+  }
+});
+
+test("a published document is private, because its base URL is the capability", () => {
+  reset();
+  for (const harness of routedHarnesses()) {
+    manager(harness.id).install();
+    const mode = statSync(DOCUMENTS[harness.id]).mode & 0o777;
+    assert.equal(mode & 0o077, 0, `${harness.id} document is group/other readable`);
+  }
+});
+
+test("publishing preserves comments, sibling providers, and unrelated settings", () => {
+  reset();
+  mkdirSync(path.dirname(DOCUMENTS.hermes), { recursive: true });
+  writeFileSync(DOCUMENTS.hermes, [
+    "# my hermes config",
+    "model:",
+    '  provider: "openrouter"',
+    '  default: "anthropic/claude-opus-4.8"',
+    "providers:",
+    "  # a local server I run",
+    "  local:",
+    "    api: http://localhost:8080/v1",
+    "    transport: chat_completions",
+    "terminal:",
+    "  backend: docker",
+    "",
+  ].join("\n"));
+
+  const client = manager("hermes");
+  client.install();
+  const published = readFileSync(DOCUMENTS.hermes, "utf8");
+  assert.match(published, /# my hermes config/);
+  assert.match(published, /# a local server I run/);
+  assert.match(published, /backend: docker/);
+  assert.match(published, /codex-router:/);
+
+  client.uninstall();
+  const restored = readFileSync(DOCUMENTS.hermes, "utf8");
+  assert.doesNotMatch(restored, /codex-router/);
+  assert.match(restored, /# a local server I run/);
+  assert.match(restored, /transport: chat_completions/);
+  assert.match(restored, /backend: docker/);
+});
+
+test("a JSON client keeps every provider it already had", () => {
+  reset();
+  mkdirSync(path.dirname(DOCUMENTS.opencode), { recursive: true });
+  writeFileSync(DOCUMENTS.opencode, `${JSON.stringify({
+    $schema: "https://opencode.ai/config.json",
+    autoupdate: true,
+    provider: { mine: { npm: "@ai-sdk/openai-compatible" } },
+  }, null, 2)}\n`);
+
+  const client = manager("opencode");
+  client.install();
+  const published = JSON.parse(readFileSync(DOCUMENTS.opencode, "utf8"));
+  assert.equal(published.autoupdate, true);
+  assert.deepEqual(published.provider.mine, { npm: "@ai-sdk/openai-compatible" });
+  // No default was set, so the router claims it.
+  assert.equal(published.model, "codex-router/moonshot/kimi-k3");
+
+  client.uninstall();
+  const restored = JSON.parse(readFileSync(DOCUMENTS.opencode, "utf8"));
+  assert.deepEqual(restored.provider, { mine: { npm: "@ai-sdk/openai-compatible" } });
+  assert.equal(restored.model, undefined);
+});
+
+test("a default model the user chose is neither taken over nor removed", () => {
+  reset();
+  mkdirSync(path.dirname(DOCUMENTS.opencode), { recursive: true });
+  writeFileSync(DOCUMENTS.opencode, `${JSON.stringify({ model: "anthropic/claude-sonnet-5" }, null, 2)}\n`);
+
+  const client = manager("opencode");
+  const result = client.install();
+  assert.equal(result.defaultOwned, false);
+  assert.equal(JSON.parse(readFileSync(DOCUMENTS.opencode, "utf8")).model, "anthropic/claude-sonnet-5");
+
+  client.uninstall();
+  assert.equal(JSON.parse(readFileSync(DOCUMENTS.opencode, "utf8")).model, "anthropic/claude-sonnet-5");
+});
+
+test("a default this router owned, then the user changed, stays the user's", () => {
+  reset();
+  const client = manager("opencode");
+  assert.equal(client.install().defaultOwned, true);
+
+  const document = JSON.parse(readFileSync(DOCUMENTS.opencode, "utf8"));
+  document.model = "anthropic/claude-opus-4.8";
+  writeFileSync(DOCUMENTS.opencode, `${JSON.stringify(document, null, 2)}\n`);
+
+  assert.equal(client.install().defaultOwned, false);
+  assert.equal(JSON.parse(readFileSync(DOCUMENTS.opencode, "utf8")).model, "anthropic/claude-opus-4.8");
+  client.uninstall();
+  assert.equal(JSON.parse(readFileSync(DOCUMENTS.opencode, "utf8")).model, "anthropic/claude-opus-4.8");
+});
+
+test("a codex-router provider this router did not write is never replaced or removed", () => {
+  reset();
+  mkdirSync(path.dirname(DOCUMENTS.omp), { recursive: true });
+  const foreign = [
+    "providers:",
+    "  codex-router:",
+    "    baseUrl: https://someone-elses-proxy.example.com/v1",
+    "    api: openai-completions",
+    "",
+  ].join("\n");
+  writeFileSync(DOCUMENTS.omp, foreign);
+
+  const client = manager("omp");
+  assert.throws(() => client.install(), /unmanaged codex-router provider/);
+  assert.equal(readFileSync(DOCUMENTS.omp, "utf8"), foreign);
+  assert.throws(() => client.uninstall(), /Refusing to remove an unmanaged/);
+  assert.equal(readFileSync(DOCUMENTS.omp, "utf8"), foreign);
+});
+
+test("a JSON document with comments is refused rather than reformatted", () => {
+  reset();
+  mkdirSync(path.dirname(DOCUMENTS.commandcode), { recursive: true });
+  const commented = '// my providers\n{\n  "provider": {}\n}\n';
+  writeFileSync(DOCUMENTS.commandcode, commented);
+  assert.throws(() => manager("commandcode").install(), /not plain JSON/);
+  assert.equal(readFileSync(DOCUMENTS.commandcode, "utf8"), commented);
+});
+
+test("opencode refuses to publish while a JSONC sibling it also reads exists", () => {
+  reset();
+  mkdirSync(path.dirname(DOCUMENTS.opencode), { recursive: true });
+  writeFileSync(path.join(path.dirname(DOCUMENTS.opencode), "opencode.jsonc"), "// hi\n{}\n");
+  assert.throws(() => manager("opencode").install(), /opencode\.jsonc/);
+  assert.equal(existsSync(DOCUMENTS.opencode), false);
+});
+
+test("a failed marker write puts the client's document back", () => {
+  reset();
+  mkdirSync(path.dirname(DOCUMENTS.pi), { recursive: true });
+  writeFileSync(DOCUMENTS.pi, `${JSON.stringify({ providers: { ollama: { baseUrl: "http://localhost:11434/v1" } } }, null, 2)}\n`);
+  const before = readFileSync(DOCUMENTS.pi, "utf8");
+
+  const client = manager("pi", {
+    writeMarker: () => {
+      throw new Error("marker write failed");
+    },
+  });
+  assert.throws(() => client.install(), /marker write failed/);
+  assert.equal(readFileSync(DOCUMENTS.pi, "utf8"), before);
+});
+
+test("a malformed publication marker refuses to change client state", () => {
+  reset();
+  manager("pi").install();
+  writeFileSync(path.join(stateDir, "pi-models.json"), '{"version":2}\n', { mode: 0o600 });
+  assert.throws(() => manager("pi").install(), /malformed shape/);
+  assert.throws(() => manager("pi").uninstall(), /malformed shape/);
+  assert.equal(manager("pi").status().stateValid, false);
+});
+
+test("publishing with no routable models is refused before anything is written", () => {
+  reset();
+  const client = manager("hermes", { modelSource: () => ({ models: [], engine: null }) });
+  assert.throws(() => client.install(), /No routed models are selected/);
+  assert.equal(existsSync(DOCUMENTS.hermes), false);
+});
+
+test("the catalog names one wire, one document, and one provider key per client", () => {
+  assert.deepEqual(ROUTED_HARNESS_IDS, ["opencode", "pi", "omp", "commandcode", "hermes"]);
+  const documents = new Set();
+  for (const harness of routedHarnesses()) {
+    assert.ok(["json", "yaml"].includes(harness.format));
+    assert.ok(["responses", "anthropic"].includes(harness.wire));
+    assert.equal(harness.providerPath.at(-1), "codex-router");
+    assert.ok(harness.baseUrlPath.length >= 1);
+    assert.equal(documents.has(harness.documentKey), false, "two clients must not share one document");
+    documents.add(harness.documentKey);
+  }
+  // Hermes ships no package-registry install, so this router never offers to
+  // install it; the others are installable where their package has a build.
+  assert.equal(routedHarness("hermes").npmPackage, undefined);
+  assert.equal(routedHarnessInstallable("hermes"), false);
+  assert.equal(routedHarnessInstallable("opencode"), true);
+  assert.equal(routedHarnessInstallable("omp", { platform: "win32" }), false);
+  assert.equal(routedHarnessInstallable("omp", { platform: "darwin" }), true);
+});
+
+test("the YAML helpers only ever touch the key they are given", () => {
+  const document = [
+    "root:",
+    "  keep: 1",
+    "  providers:",
+    "    other:",
+    "      api: https://example.com",
+    "",
+  ].join("\n");
+  const written = applyYamlValue(document, ["root", "providers", "codex-router"], {
+    api: "http://127.0.0.1:4202/x",
+    models: { "a/b:c": {} },
+  });
+  assert.match(written, /keep: 1/);
+  assert.match(written, /other:/);
+  // A model id carrying `/` and `:` has to be quoted, or the mapping key
+  // silently becomes something else.
+  assert.match(written, /"a\/b:c": \{\}/);
+  assert.equal(
+    yamlLeafScalar(written, ["root", "providers", "codex-router", "api"]),
+    "http://127.0.0.1:4202/x",
+  );
+  const cleared = removeYamlValue(written, ["root", "providers", "codex-router"]);
+  assert.doesNotMatch(cleared, /codex-router/);
+  assert.match(cleared, /other:/);
+  assert.match(cleared, /keep: 1/);
+});
+
+test("the Control Center's copy of the harness table matches the router's", async () => {
+  // The app must be able to draw the Harness tab before it can load a module
+  // out of the installed router, so `ipc.mjs` keeps its own detection table.
+  // A drift between the two is silent and looks like "nothing is published",
+  // which is exactly the failure this asserts away.
+  const source = await import("node:fs/promises").then((fs) => fs.readFile(
+    new URL("../apps/control-center/electron/ipc.mjs", import.meta.url),
+    "utf8",
+  ));
+  const rows = source.slice(
+    source.indexOf("const ROUTED_HARNESS_ROWS = Object.freeze(["),
+    source.indexOf("const ROUTED_HARNESS_IDS = ROUTED_HARNESS_ROWS"),
+  );
+  assert.ok(rows.length > 0, "the Control Center harness table should be readable");
+  assert.deepEqual(
+    [...rows.matchAll(/^    id: "([a-z-]+)",$/gm)].map((match) => match[1]),
+    ROUTED_HARNESS_IDS,
+  );
+  for (const harness of routedHarnesses()) {
+    assert.match(rows, new RegExp(`marker: "${harness.id}-models\\.json"`));
+    assert.match(rows, new RegExp(`binEnv: "${harness.binEnv}"`));
+    assert.match(rows, new RegExp(`docs: "${harness.docsUrl.replaceAll("/", "\\/")}"`));
+    assert.match(rows, new RegExp(`site: "${harness.siteUrl.replaceAll("/", "\\/")}"`));
+    // The marker filename the app looks for has to be the one the publisher
+    // writes, or a published client renders as "Not published" forever.
+    assert.equal(
+      path.basename(ROUTED_HARNESS_CATALOG_PATHS[harness.id]),
+      `${harness.id}-models.json`,
+    );
+  }
+});
+
+test.after(() => rmSync(root, { recursive: true, force: true }));

--- a/test/routed-harness.test.mjs
+++ b/test/routed-harness.test.mjs
@@ -32,9 +32,13 @@ const { ROUTED_HARNESS_IDS, routedHarness, routedHarnesses } = await import(
   "../src/routed-harness-catalog.mjs"
 );
 const { createRoutedHarnessManager } = await import("../src/routed-harness-manager.mjs");
-const { installRoutedHarness, routedHarnessInstallable, routedHarnessOutdated } = await import(
-  "../src/routed-harness-install.mjs"
-);
+const {
+  installRoutedHarness,
+  routedHarnessInstallable,
+  routedHarnessOutdated,
+  routedHarnessUpdatable,
+  updateRoutedHarness,
+} = await import("../src/routed-harness-install.mjs");
 const { applyYamlValue, removeYamlValue, yamlLeafScalar } = await import(
   "../src/routed-harness-document.mjs"
 );
@@ -451,6 +455,79 @@ test("the YAML helpers only ever touch the key they are given", () => {
   assert.match(cleared, /keep: 1/);
 });
 
+test("updating a client runs that client's own updater, not npm", () => {
+  // A CLI installed by Homebrew or a `curl | sh` script is not an npm package.
+  // Reinstalling it as one leaves two copies and lets PATH order decide which
+  // runs — the failure where the row reports the new version and the shell
+  // keeps running the old one. Every client that ships an updater gets it.
+  for (const [id, expected] of [
+    ["opencode", ["upgrade"]],
+    ["pi", ["update", "--self"]],
+    ["commandcode", ["update"]],
+    ["hermes", ["update", "--yes"]],
+  ]) {
+    const ran = [];
+    const result = updateRoutedHarness(id, {
+      find: () => `/usr/local/bin/${id}`,
+      version: () => (ran.length ? "9.9.9" : "1.0.0"),
+      install: () => assert.fail(`${id} must update through its own CLI, not npm`),
+      run: (command, args) => ran.push([command, args]),
+    });
+    assert.deepEqual(ran.at(-1)[1].slice(-expected.length), expected);
+    assert.deepEqual(
+      { from: result.from, to: result.to, changed: result.changed },
+      { from: "1.0.0", to: "9.9.9", changed: true },
+    );
+  }
+});
+
+test("a client with no updater of its own is reinstalled at latest, or explained", () => {
+  // pi moved publishers; installing the abandoned name pins a stale agent that
+  // still answers `pi --version`, so nothing downstream would call it wrong.
+  assert.equal(routedHarness("pi").npmPackage, "@earendil-works/pi-coding-agent@latest");
+
+  // omp has neither a package this router installs nor a self-update
+  // subcommand, so the only honest answer is the project's own instructions.
+  assert.equal(routedHarnessUpdatable("omp"), false);
+  assert.throws(
+    () => updateRoutedHarness("omp", {
+      find: () => "/usr/local/bin/omp",
+      version: () => "1.0.0",
+      install: () => assert.fail("omp is never npm-installed"),
+      run: () => assert.fail("omp has no updater to run"),
+    }),
+    /omp\.sh|brew install/,
+  );
+
+  // Hermes has no package but does maintain its own checkout.
+  assert.equal(routedHarnessInstallable("hermes"), false);
+  assert.equal(routedHarnessUpdatable("hermes"), true);
+
+  // A client that reports no version cannot be claimed to have changed.
+  const silent = updateRoutedHarness("opencode", {
+    find: () => "/usr/local/bin/opencode",
+    version: () => undefined,
+    install: () => {},
+    run: () => {},
+  });
+  assert.deepEqual(
+    { changed: silent.changed, versionReported: silent.versionReported },
+    { changed: false, versionReported: false },
+  );
+});
+
+test("a failing updater reports the command that failed", () => {
+  assert.throws(
+    () => updateRoutedHarness("opencode", {
+      find: () => "/usr/local/bin/opencode",
+      version: () => "1.0.0",
+      install: () => {},
+      run: () => { throw Object.assign(new Error("spawn failed"), { stderr: "network unreachable" }); },
+    }),
+    /opencode upgrade.*network unreachable/s,
+  );
+});
+
 test("the Control Center's copy of the harness table matches the router's", async () => {
   // The app must be able to draw the Harness tab before it can load a module
   // out of the installed router, so `ipc.mjs` keeps its own detection table.
@@ -474,6 +551,14 @@ test("the Control Center's copy of the harness table matches the router's", asyn
     assert.match(rows, new RegExp(`binEnv: "${harness.binEnv}"`));
     assert.match(rows, new RegExp(`docs: "${harness.docsUrl.replaceAll("/", "\\/")}"`));
     assert.match(rows, new RegExp(`site: "${harness.siteUrl.replaceAll("/", "\\/")}"`));
+    // The Update button's tooltip promises a specific command. If the app's
+    // copy drifts from the catalog the button lies about what it will run.
+    assert.match(
+      rows,
+      harness.updateCommand
+        ? new RegExp(`updater: "${harness.executables[0]} ${harness.updateCommand.join(" ")}"`)
+        : /updater: null/,
+    );
     // The marker filename the app looks for has to be the one the publisher
     // writes, or a published client renders as "Not published" forever.
     assert.equal(

--- a/test/routed-harness.test.mjs
+++ b/test/routed-harness.test.mjs
@@ -32,7 +32,9 @@ const { ROUTED_HARNESS_IDS, routedHarness, routedHarnesses } = await import(
   "../src/routed-harness-catalog.mjs"
 );
 const { createRoutedHarnessManager } = await import("../src/routed-harness-manager.mjs");
-const { routedHarnessInstallable } = await import("../src/routed-harness-install.mjs");
+const { installRoutedHarness, routedHarnessInstallable, routedHarnessOutdated } = await import(
+  "../src/routed-harness-install.mjs"
+);
 const { applyYamlValue, removeYamlValue, yamlLeafScalar } = await import(
   "../src/routed-harness-document.mjs"
 );
@@ -43,6 +45,7 @@ const MODELS = [
     slug: "moonshot/kimi-k3",
     displayName: "Kimi K3",
     contextWindow: 262_144,
+    autoCompact: 222_822,
     inputModalities: ["text"],
     reasoningLevels: [{ effort: "low" }, { effort: "high" }],
     priority: 10,
@@ -301,9 +304,123 @@ test("the catalog names one wire, one document, and one provider key per client"
   // install it; the others are installable where their package has a build.
   assert.equal(routedHarness("hermes").npmPackage, undefined);
   assert.equal(routedHarnessInstallable("hermes"), false);
+  // omp's npm package runs on Bun, so an npm install without Bun would leave an
+  // `omp` that cannot start. It is installed from its own instructions.
+  assert.equal(routedHarnessInstallable("omp"), false);
+  assert.deepEqual(routedHarness("omp").executables, ["omp"]);
   assert.equal(routedHarnessInstallable("opencode"), true);
-  assert.equal(routedHarnessInstallable("omp", { platform: "win32" }), false);
-  assert.equal(routedHarnessInstallable("omp", { platform: "darwin" }), true);
+});
+
+test("opencode gets a limit its schema accepts, compacting where Codex does", () => {
+  reset();
+  manager("opencode").install();
+  const { models } = JSON.parse(readFileSync(DOCUMENTS.opencode, "utf8")).provider["codex-router"];
+  // opencode rejects the whole document when `limit` lacks `output`.
+  assert.deepEqual(models["moonshot/kimi-k3"].limit, { context: 262_144, input: 222_822, output: 39_322 });
+  // No compaction threshold, no limit: unknown rather than a guess.
+  assert.equal(models["x-ai/grok-4.6"].limit, undefined);
+});
+
+test("Command Code models carry only the fields its loader reads", () => {
+  reset();
+  manager("commandcode").install();
+  const { models } = JSON.parse(readFileSync(DOCUMENTS.commandcode, "utf8")).provider["codex-router"];
+  assert.deepEqual(models["codex_router/anthropic/moonshot/kimi-k3"], {
+    name: "Kimi K3",
+    contextWindow: 262_144,
+    reasoningEfforts: ["low", "high"],
+  });
+  assert.deepEqual(models["codex_router/anthropic/x-ai/grok-4.6"], { name: "Grok 4.6", contextWindow: 2_000_000 });
+});
+
+test("a Command Code too old to read providers.json is updated, not published past", () => {
+  const installs = [];
+  const upgraded = installRoutedHarness("commandcode", {
+    find: () => "/usr/local/bin/command-code",
+    version: () => (installs.length ? "1.53.0" : "1.26.0"),
+    install: (spec) => installs.push(spec),
+  });
+  assert.deepEqual(installs, ["command-code@latest"]);
+  assert.equal(upgraded.upgraded, true);
+
+  const current = installRoutedHarness("commandcode", {
+    find: () => "/usr/local/bin/command-code",
+    version: () => "1.30.0",
+    install: () => assert.fail("a current CLI must not be reinstalled"),
+  });
+  assert.equal(current.changed, false);
+
+  // npm updated its copy but an older install still wins on PATH.
+  assert.throws(
+    () => installRoutedHarness("commandcode", { find: () => "/opt/cc", version: () => "1.26.0", install: () => {} }),
+    /still older than 1\.30\.0/,
+  );
+  assert.throws(
+    () => installRoutedHarness("omp", { find: () => undefined, install: () => assert.fail("omp is never npm-installed") }),
+    /omp\.sh/,
+  );
+
+  assert.equal(routedHarnessOutdated("commandcode", "1.29.9"), true);
+  assert.equal(routedHarnessOutdated("commandcode", "command-code 1.30.0"), false);
+  assert.equal(routedHarnessOutdated("commandcode", undefined), false);
+  assert.equal(routedHarnessOutdated("opencode", "0.0.1"), false);
+
+  const status = manager("commandcode", { cliVersion: () => "1.26.0" }).status();
+  assert.equal(status.cliOutdated, true);
+  assert.equal(status.cliVersion, "1.26.0");
+  assert.equal(status.cliMinimumVersion, "1.30.0");
+});
+
+test("an injected marker file is the one read back, not the state directory's", () => {
+  reset();
+  const markerFile = path.join(root, "elsewhere", "pi-marker.json");
+  const client = manager("pi", { markerFile });
+  client.install();
+  assert.equal(existsSync(markerFile), true);
+  assert.equal(existsSync(path.join(stateDir, "pi-models.json")), false);
+  const status = client.status();
+  assert.equal(status.installed, true);
+  assert.equal(status.catalogFresh, true);
+  assert.equal(client.uninstall().removed, true);
+  assert.equal(existsSync(markerFile), false);
+  rmSync(path.dirname(markerFile), { recursive: true, force: true });
+});
+
+test("pi, omp, and Command Code documents resolve the way those clients resolve them", async () => {
+  const { execFileSync } = await import("node:child_process");
+  const home = path.join(root, "home");
+  const agentDir = path.join(root, "agent-override");
+  const resolve = (extra) => {
+    const env = { ...process.env, HOME: home, USERPROFILE: home, ...extra };
+    for (const key of ["MODEL_ROUTER_PI_MODELS", "MODEL_ROUTER_OMP_MODELS", "MODEL_ROUTER_COMMANDCODE_PROVIDERS"]) {
+      delete env[key];
+    }
+    if (!extra.PI_CODING_AGENT_DIR) delete env.PI_CODING_AGENT_DIR;
+    const script =
+      "const p = await import(process.argv[1]);" +
+      "console.log(JSON.stringify({ pi: p.PI_MODELS_PATH, omp: p.OMP_MODELS_PATH, commandcode: p.COMMANDCODE_PROVIDERS_PATH }));";
+    return JSON.parse(execFileSync(
+      process.execPath,
+      ["--input-type=module", "-e", script, new URL("../src/paths.mjs", import.meta.url).href],
+      { env, encoding: "utf8" },
+    ));
+  };
+
+  const defaults = resolve({});
+  assert.equal(defaults.pi, path.join(home, ".pi", "agent", "models.json"));
+  // `~/.omp`, the upstream's home -- not the `~/.oh-omp` a fork reads.
+  assert.equal(defaults.omp, path.join(home, ".omp", "agent", "models.yml"));
+  assert.equal(defaults.commandcode, path.join(home, ".commandcode", "providers.json"));
+
+  const overridden = resolve({ PI_CODING_AGENT_DIR: agentDir });
+  assert.equal(overridden.pi, path.join(agentDir, "models.json"));
+  assert.equal(overridden.omp, path.join(agentDir, "models.yml"));
+
+  // omp reads `models.yaml` when there is no `models.yml`; creating one would
+  // shadow the user's file.
+  mkdirSync(agentDir, { recursive: true });
+  writeFileSync(path.join(agentDir, "models.yaml"), "providers: {}\n");
+  assert.equal(resolve({ PI_CODING_AGENT_DIR: agentDir }).omp, path.join(agentDir, "models.yaml"));
 });
 
 test("the YAML helpers only ever touch the key they are given", () => {

--- a/test/routed-harness.test.mjs
+++ b/test/routed-harness.test.mjs
@@ -135,8 +135,13 @@ test("a published document is private, because its base URL is the capability", 
   reset();
   for (const harness of routedHarnesses()) {
     manager(harness.id).install();
-    const mode = statSync(DOCUMENTS[harness.id]).mode & 0o777;
-    assert.equal(mode & 0o077, 0, `${harness.id} document is group/other readable`);
+    // Windows carries this as an ACL, not a POSIX mode: Node reports 0o666
+    // there whatever `protectPrivateFile` did. `privateFileIsProtected` is the
+    // check that is meaningful on both, and doctor already runs it.
+    if (process.platform !== "win32") {
+      const mode = statSync(DOCUMENTS[harness.id]).mode & 0o777;
+      assert.equal(mode & 0o077, 0, `${harness.id} document is group/other readable`);
+    }
   }
 });
 
@@ -275,6 +280,23 @@ test("a failed marker write puts the client's document back", () => {
   });
   assert.throws(() => client.install(), /marker write failed/);
   assert.equal(readFileSync(DOCUMENTS.pi, "utf8"), before);
+});
+
+test("a failed first publication leaves no document behind, not an empty one", () => {
+  // Rolling a never-published client "back" to an empty string leaves a
+  // zero-byte opencode.json or models.json, which is not valid JSON and is
+  // worse for the client than the absence this path exists to restore.
+  for (const harness of routedHarnesses()) {
+    reset();
+    assert.equal(existsSync(DOCUMENTS[harness.id]), false);
+    const client = manager(harness.id, {
+      writeMarker: () => {
+        throw new Error("marker write failed");
+      },
+    });
+    assert.throws(() => client.install(), /marker write failed/);
+    assert.equal(existsSync(DOCUMENTS[harness.id]), false, `${harness.id} left a document behind`);
+  }
 });
 
 test("a malformed publication marker refuses to change client state", () => {

--- a/test/routed-harness.test.mjs
+++ b/test/routed-harness.test.mjs
@@ -179,6 +179,67 @@ test("publishing preserves comments, sibling providers, and unrelated settings",
   assert.match(restored, /backend: docker/);
 });
 
+test("a YAML shape this reader cannot account for is refused, never spliced", () => {
+  // `children` is the lexer's map of mapping keys it could register. A block
+  // sequence, or a key such as `openrouter/free:` that the key grammar
+  // declines, lives inside a node while being invisible there. Publishing into
+  // one produced a document the client could not parse, and removing it then
+  // judged the whole `providers:` block "ours alone" and spliced it away --
+  // the user's file came back zero bytes.
+  const unreadable = {
+    "a providers block written as a sequence": [
+      "providers:",
+      "  - name: mine",
+      "    api: http://localhost:8080/v1",
+      "",
+    ].join("\n"),
+    "a provider id the key grammar declines": [
+      "providers:",
+      "  openrouter/free:",
+      "    api: http://localhost:8080/v1",
+      "",
+    ].join("\n"),
+  };
+
+  for (const [shape, contents] of Object.entries(unreadable)) {
+    reset();
+    mkdirSync(path.dirname(DOCUMENTS.hermes), { recursive: true });
+    writeFileSync(DOCUMENTS.hermes, contents);
+    assert.throws(() => manager("hermes").install(), /account for|ambiguous/i, shape);
+    assert.equal(readFileSync(DOCUMENTS.hermes, "utf8"), contents, `${shape}: file must be untouched`);
+  }
+});
+
+test("removing the routed provider restores a YAML document byte for byte", () => {
+  // The substring assertions elsewhere pass even when bytes the router does
+  // not own are dropped. These compare the whole file.
+  const shapes = {
+    "a sibling provider": "providers:\n  local:\n    api: http://localhost:8080/v1\n",
+    "a comment beside our key": "providers:\n  local:\n    api: http://x\n  # keep me\n",
+    // The one that broke: `providers:` holding nothing but a comment. Our key
+    // is then its only *registered* child, and the comment sits outside the
+    // node's `endIndex`, so the ancestor collapse judged the block ours alone
+    // and took `providers:` with it, leaving the comment orphaned at the wrong
+    // indentation.
+    "a comment as the only thing beside our key":
+      'model:\n  default: "x"\nproviders:\n  # I plan to add one\n',
+    "settings on both sides": "model:\n  default: \"x\"\nproviders:\n  local:\n    api: http://x\nterminal:\n  backend: docker\n",
+  };
+
+  for (const [shape, contents] of Object.entries(shapes)) {
+    reset();
+    mkdirSync(path.dirname(DOCUMENTS.hermes), { recursive: true });
+    writeFileSync(DOCUMENTS.hermes, contents);
+
+    const client = manager("hermes");
+    client.install();
+    assert.match(readFileSync(DOCUMENTS.hermes, "utf8"), /codex-router:/, shape);
+
+    client.uninstall();
+    assert.equal(readFileSync(DOCUMENTS.hermes, "utf8"), contents, shape);
+  }
+});
+
 test("a JSON client keeps every provider it already had", () => {
   reset();
   mkdirSync(path.dirname(DOCUMENTS.opencode), { recursive: true });

--- a/test/target-integration.test.mjs
+++ b/test/target-integration.test.mjs
@@ -20,6 +20,7 @@ const {
   DSH_CATALOG_PATH,
   NATIVE_CATALOG_PATH,
   OPENCLAW_CATALOG_PATH,
+  ROUTED_HARNESS_CATALOG_PATHS,
 } = await import("../src/paths.mjs");
 
 function stageFile(filePath, contents) {
@@ -28,7 +29,10 @@ function stageFile(filePath, contents) {
 }
 
 function clearStagedFiles() {
-  for (const filePath of [CONFIG_PATH, CLAUDE_CATALOG_PATH, CURSOR_CATALOG_PATH, DSH_CATALOG_PATH, NATIVE_CATALOG_PATH, OPENCLAW_CATALOG_PATH]) {
+  for (const filePath of [
+    CONFIG_PATH, CLAUDE_CATALOG_PATH, CURSOR_CATALOG_PATH, DSH_CATALOG_PATH, NATIVE_CATALOG_PATH,
+    OPENCLAW_CATALOG_PATH, ...Object.values(ROUTED_HARNESS_CATALOG_PATHS),
+  ]) {
     rmSync(filePath, { force: true });
   }
 }
@@ -215,6 +219,24 @@ test("a config that exists but cannot be read still counts as installed", () => 
     assert.deepEqual(installedTargets(), ["codex"]);
   } finally {
     rmSync(CONFIG_PATH, { recursive: true, force: true });
+    clearStagedFiles();
+  }
+});
+
+test("a routed harness publication keeps the shared plane installed", () => {
+  try {
+    // opencode, pi, omp, Command Code, and Hermes are published *into* rather
+    // than installed *as*, so they are no `MODEL_ROUTER_TARGET`. They still
+    // hold the shared service open: `bin/disable` retires it only once this
+    // list is empty, and omitting them is how turning Codex off would stop
+    // opencode working.
+    stageFile(ROUTED_HARNESS_CATALOG_PATHS.opencode, "{}");
+    assert.deepEqual(installedTargets(), ["opencode"]);
+    stageFile(ROUTED_HARNESS_CATALOG_PATHS.hermes, "{}");
+    assert.deepEqual(installedTargets(), ["opencode", "hermes"]);
+    stageFile(CONFIG_PATH, "# BEGIN codex-router-managed\n# END codex-router-managed\n");
+    assert.deepEqual(installedTargets(), ["codex", "opencode", "hermes"]);
+  } finally {
     clearStagedFiles();
   }
 });


### PR DESCRIPTION
Adds opencode, pi, omp (oh-my-pi), Command Code, and Hermes Agent to the Harness tab. Each keeps its providers in a configuration document the user also owns, so one shared publisher (`src/routed-harness-*.mjs`) writes the single `codex-router` key each of them reads and leaves every other byte alone.

Devin CLI and T3 Code are deliberately absent: Devin CLI selects from Cognition-hosted models and has no custom base URL, and T3 Code drives other CLIs rather than talking to models itself. A row that cannot publish is a row that lies.

## What is here

- **Publish** — `control client-setup <id>` / `client-disconnect <id>` and the Harness row's **Set up**. The wire is always one the router already serves: Responses on the caller `/v1` path for opencode, pi, and omp; the existing Anthropic Messages surface with `codex_router/anthropic/<slug>` ids for Command Code and Hermes, which have no Responses client.
- **Stay current** — `control client-update <id>|--all`, an **Update** button per row, and **Update all**. Each runs the client's *own* updater (`opencode upgrade`, `pi update --self`, `command-code update`, `hermes update --yes`) rather than `npm install -g`: a CLI installed by Homebrew or a `curl | sh` script is not an npm package, and reinstalling it as one leaves two copies whose winner is PATH order. Updating is never a side effect of publishing.
- **A keep-alive after the terminal event is dropped** (`src/openai-adapters.mjs`) — see below.
- **pi is installed from its maintained package**: it moved from `@mariozechner/pi-coding-agent` (stalled at 0.73.1) to `@earendil-works/pi-coding-agent`. The abandoned name installs fine and answers `pi --version`, so nothing here reported it as wrong.

## The stream fix, verified end to end

OpenCode Go and Zen close every Responses stream with a `ping` after `response.completed`. The forwarder read that as data after the terminal event and appended `invalid_responses_stream`, which LiteLLM re-raised on every completed turn. Codex ignores bytes after a terminal event, so it went unnoticed; opencode's AI SDK and pi validate them and failed the turn.

1. **Reproduced on the live router** — a real turn on the free `opencode-free-responses/muse-spark-1.2-contributor-free` route returned `"status":"completed"` with usage counted, then `{"error":{"message":"litellm.APIError: Response API in-stream error","code":"500"}}`.
2. **Confirmed the frame** — the raw upstream from `opencode.ai/zen/v1/responses` ends with exactly `event: ping` / `{"type":"ping","cost":"0"}`.
3. **Replayed those real bytes through both transforms:**

```
upstream : … response.output_item.done, response.completed, ping
OLD emits: … response.output_item.done, response.completed, error
NEW emits: … response.output_item.done, response.completed
only difference: error
```

Real data after the terminal event is still refused.

## Other verification

- opencode 1.18.13 read a published document from a scratch config and listed all 13 routed models (exit 0, empty stderr). This is the check that caught opencode's `limit.output` schema requirement, which the unit suite had passed straight through.
- The JSONC guard fires on a real layout: with an `opencode.jsonc` present, publication stops with an explanation and writes nothing.
- 190 tests pass / 0 fail across the harness, adapters, control-center, control, target-integration, caller-key, and YAML suites.

## Not verified

No routed turn has been taken *through* one of the five clients end to end — the live service runs from the main checkout, so proving that needs a second router instance. `AGENTS.md` now records that listing alone is insufficient, which is exactly how the `ping` bug hid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
