### PR TITLE
fix: keep Hy4 turns alive — replay reasoning natively, recover leaked tool calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1965,9 +1965,14 @@ retry rules on the shared path.
   constraints use the existing adapters. Never infer tools from name prefixes or
   create declarations from metadata alone; ambiguous and ordinary-name
   collisions remain unchanged.
-- GLM thinking, legacy DeepSeek thinking and Command Code's DeepSeek Flash Chat
-  route carry reasoning through LiteLLM as assistant `thinking` parts, restored
-  by the forwarder to `reasoning_content`. Remove only successfully carried
+- GLM thinking, legacy DeepSeek thinking, Hy4 Preview (`hy4-reasoning`) and
+  Command Code's DeepSeek Flash Chat route carry reasoning through LiteLLM as
+  assistant `thinking` parts, restored by the forwarder to `reasoning_content`.
+  An interleaved-thinking model that instead sees its past reasoning replayed as
+  visible assistant text moves new thinking into the answer channel and loops
+  on its last progress note (Hy4 on opencode Go, 12 September 2026: 2, 4, 5,
+  8, 16 copies per message). Add a thinking model to this contract in
+  `src/chat-reasoning.mjs`, not by special-casing the carry. Remove only successfully carried
   reasoning runs so plaintext cannot also become a user message. Do not mutate
   source items or change other native Responses routes. Keep this policy shared
   between hops without applying direct DeepSeek sampling parameters to resellers.
@@ -2108,6 +2113,45 @@ label, so `src/message-phase.mjs` assigns one.
    already sequential. Coverage lives in `test/message-phase.test.mjs`, the
    routed case in `test/namespace-relay-routing.test.mjs`, and the generic
    Responses input case in `test/generic-routing.test.mjs`.
+
+## A model that writes its tool calls as text has them recovered, not relayed
+
+Tencent Hy4 Preview carries a tool-call syntax of its own,
+`<tool_calls:NONCE><tool_call:NONCE>name<arg_key:NONCE>k</arg_key:NONCE><arg_value:NONCE>v</arg_value:NONCE>...`.
+Serving stacks disagree about it: the agent-check tool probe recorded
+`commandcode/hy4-preview` failing on exactly this markup while
+`opencode-go/hy4-preview` passed the same probe minutes later, and the
+opencode-go route then leaked it intermittently mid-session. Nothing reaches the
+`tool_calls` array on a leaked turn, so LiteLLM's chat-completions -> Responses
+bridge relays a reasoning item followed by an assistant message with empty
+content and no `function_call`. Codex ends the turn there and writes
+`task_complete` with `last_agent_message: null`: the client shows its
+"Worked for ..." group and no answer at all, with no error anywhere.
+
+`src/leaked-tool-call-recovery.mjs` parses that markup back into real
+`function_call` items.
+
+1. **Only the model's own calls.** The transform relays a call the model wrote;
+   it never authors one. A span that is unterminated, carries a mismatched
+   nonce, names something that is not a tool name, or fails to parse for any
+   other reason is relayed verbatim and recovers nothing. A stream without the
+   markup is passed through byte-for-byte, and invalid UTF-8 disables rewriting
+   for the rest of the stream.
+2. **The nonce is read, never assumed.** `6124c78e` appears in every capture to
+   date, on both routes, but it is taken from the opening tag and the closing
+   tag must repeat it. Do not hardcode it.
+3. **One item contributes its calls once.** The same span arrives on the delta
+   channel, in the `.done` snapshot, and in the stored item; recovery is keyed
+   by output index so the call is emitted a single time.
+4. **A leaked argument value is text.** It is read as JSON only when its text is
+   exactly its own JSON form, so a declared `20000` or `true` survives while a
+   shell command, a path, or `0755` stays the string the model wrote.
+5. **Routed streams only, before the namespace transform**, so a recovered
+   flattened `mcp__server__tool` call is restored like any other, the empty-
+   completion guard sees content, and the phase labeller reads the blank
+   message as commentary instead of a final answer. Native streams gain no
+   stage. Coverage lives in `test/leaked-tool-call-recovery.test.mjs` and the
+   leaked-channel case in `test/namespace-relay-routing.test.mjs`.
 
 ## Routed subagent regression prevention
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+- **Hy4 Preview no longer loops on its own progress notes mid-turn.** Its
+  reasoning is now replayed to it the way DeepSeek's and GLM's already were --
+  as `reasoning_content` on the assistant turn that produced it -- instead of
+  as visible assistant text. Replayed as prose, the model read its own past
+  thinking as something it had said aloud, moved new thinking into the answer
+  channel (reasoning tokens went from 174 to 0 in one step), and from there
+  repeated its last note 2, 4, 5, 8, then 16 times per message while Codex
+  showed "Reconnecting". Applies to every route on the `hy4-reasoning` profile
+  (opencode Go, OpenRouter, NanoGPT, Nous); Command Code's own Hy4 shim and
+  Cline are unchanged.
+- **A routed turn no longer dies silently when the model writes its tool calls
+  as text.** Tencent Hy4 Preview has a tool-call syntax of its own
+  (`<tool_calls:NONCE>...`). When a serving stack fails to parse it, the calls
+  arrive as ordinary text on the reasoning channel, nothing reaches the
+  `tool_calls` array, and the turn ends on an assistant message with no content
+  and no `function_call`. Codex reads that as the end of the turn and writes
+  `task_complete` with `last_agent_message: null`, so the user is left with the
+  "Worked for ..." group and no answer at all -- in the capture this was found
+  in, four minutes of work vanished mid-investigation. The router now parses the
+  leaked markup back into real `function_call` items, strips it from the text it
+  was buried in, and emits the calls before the turn closes, so the model's own
+  work continues. Only the model's calls are recovered: a malformed, unterminated
+  or nonce-mismatched span is relayed verbatim, a stream without the markup is
+  passed through byte-for-byte, and native turns gain no stage.
 - **A routed model the router has not loaded now fails locally, not at
   ChatGPT.** A model added to or renamed in `user-models.json` shows up in the
   Codex picker as soon as the catalog is rebuilt, but the running router reads

--- a/src/chat-reasoning.mjs
+++ b/src/chat-reasoning.mjs
@@ -3,10 +3,19 @@
 // it the direct DeepSeek profile would also change tool choice and sampling.
 // Both hops must agree: the router carries `thinking` parts through LiteLLM,
 // then the API forwarder restores the assistant's `reasoning_content` field.
+//
+// Hy4 Preview is an interleaved-thinking model on the same contract: its
+// reasoning arrives as `reasoning_content` and belongs back on the assistant
+// turn that produced it. Replayed as visible text instead, the model reads its
+// own past thinking as prose it once said, starts putting new thinking into the
+// answer channel, and from there loops on its last progress note (rollout
+// 01a0928e, 12 September 2026: reasoning tokens 174 -> 0 at the turn the
+// switch happened, then the same sentence 2, 4, 5, 8, 16 times).
 export function usesNativeChatReasoning(model) {
   return (
     model?.requestProfile === "glm-thinking" ||
     model?.requestProfile === "deepseek-thinking" ||
+    model?.requestProfile === "hy4-reasoning" ||
     (model?.provider === "commandcode" &&
       model?.upstreamModel === "deepseek/deepseek-v4-flash")
   );

--- a/src/leaked-tool-call-recovery.mjs
+++ b/src/leaked-tool-call-recovery.mjs
@@ -1,0 +1,564 @@
+import { randomUUID } from "node:crypto";
+import { Transform } from "node:stream";
+
+// Tencent Hy4 Preview has a native tool-call syntax of its own. When a serving
+// stack fails to parse it, the model's calls arrive as ordinary *text* on the
+// reasoning channel and nothing reaches the `tool_calls` array, so LiteLLM's
+// chat-completions -> Responses bridge relays a reasoning item followed by an
+// assistant message with empty content and no `function_call`:
+//
+//   ...Let me keep reading the behavior code while it comes up.
+//   <tool_calls:6124c78e><tool_call:6124c78e>exec_command
+//     <arg_key:6124c78e>cmd</arg_key:6124c78e>
+//     <arg_value:6124c78e>tail -5 .qa/eo-up.log</arg_value:6124c78e>
+//   </tool_call:6124c78e></tool_calls:6124c78e>
+//
+// Codex reads that as "an assistant message with nothing in it", ends the turn,
+// and writes `task_complete` with `last_agent_message: null`. The user sees the
+// "Worked for 3m 58s" group and no answer at all -- the turn dies silently in
+// the middle of the model's own work.
+//
+// This transform parses the leaked markup back into real `function_call` output
+// items and strips it from the text it was buried in. The calls are the model's
+// own -- nothing here authors a call the model did not write, and a stream
+// without the markup is passed through byte-for-byte.
+//
+// The delimiter carries a per-family constant (`6124c78e` in every capture to
+// date, on both the commandcode and opencode-go routes), but it is read from
+// the opening tag rather than hardcoded, and the closing tag must repeat it.
+//
+// Text held back while a span is still open is released as soon as the span
+// resolves one way or the other. The one case it is not is a stream that ends
+// mid-span with no `.done` snapshot and no stored item: those delta bytes are
+// dropped rather than relayed as half a tag. The item's own text is cleaned
+// independently, so the transcript still carries what the model wrote.
+
+const OPEN_MARKER = "<tool_calls:";
+const NONCE = "[0-9a-zA-Z]{1,32}";
+const OPEN_RE = new RegExp(`^<tool_calls:(${NONCE})>`);
+// Longest an opening tag can be before it is decidably not one.
+const MAX_OPEN_LEN = OPEN_MARKER.length + 32 + 1;
+// A captured span holds the model's tool arguments, which can be a sizable
+// patch or file body. Bound it anyway: past this the capture is released
+// verbatim and recovery gives up for the rest of the stream rather than
+// buffering an unterminated span without limit.
+const MAX_CAPTURE_BYTES = 4 * 1024 * 1024;
+// Tool names Codex accepts, including the flattened `mcp__server__tool` form.
+const NAME_RE = /^[A-Za-z0-9_.-]{1,128}$/;
+
+// A leaked argument value is always written as text. Accept the JSON reading
+// only when the text *is* its own JSON form -- `20000` -> 20000, `true` -> true,
+// `{"a":1}` -> the object -- so a declared number or boolean survives the round
+// trip. Everything else (shell commands, paths, prose, `0755`) stays the exact
+// string the model wrote. The one casualty is an argument whose intended string
+// value is also valid JSON, such as a literal "123"; that is rarer than a
+// genuine numeric argument, and both shapes are visible in the relayed call.
+function readArgumentValue(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (JSON.stringify(parsed) === raw) return parsed;
+  } catch {
+    // Not JSON at all: the common case.
+  }
+  return raw;
+}
+
+// Parse the inside of one `<tool_calls:N>...</tool_calls:N>` span. Returns
+// undefined -- leaving the span verbatim -- on anything malformed, so text that
+// merely resembles the markup is never eaten.
+function parseSpanBody(body, nonce) {
+  const openCall = `<tool_call:${nonce}>`;
+  const closeCall = `</tool_call:${nonce}>`;
+  const openKey = `<arg_key:${nonce}>`;
+  const closeKey = `</arg_key:${nonce}>`;
+  const openValue = `<arg_value:${nonce}>`;
+  const closeValue = `</arg_value:${nonce}>`;
+  const calls = [];
+  let rest = body;
+  while (rest.trim()) {
+    const start = rest.indexOf(openCall);
+    if (start === -1) return undefined;
+    const end = rest.indexOf(closeCall, start + openCall.length);
+    if (end === -1) return undefined;
+    const inner = rest.slice(start + openCall.length, end);
+    rest = rest.slice(end + closeCall.length);
+
+    // The name is the bare text between the call tag and its first argument.
+    const firstKey = inner.indexOf(openKey);
+    const name = (firstKey === -1 ? inner : inner.slice(0, firstKey)).trim();
+    if (!NAME_RE.test(name)) return undefined;
+
+    const args = {};
+    let argsRest = firstKey === -1 ? "" : inner.slice(firstKey);
+    while (argsRest.includes(openKey)) {
+      const keyStart = argsRest.indexOf(openKey);
+      const keyEnd = argsRest.indexOf(closeKey, keyStart + openKey.length);
+      if (keyEnd === -1) return undefined;
+      const valueStart = argsRest.indexOf(openValue, keyEnd + closeKey.length);
+      if (valueStart === -1) return undefined;
+      const valueEnd = argsRest.indexOf(closeValue, valueStart + openValue.length);
+      if (valueEnd === -1) return undefined;
+      const key = argsRest.slice(keyStart + openKey.length, keyEnd);
+      if (!key) return undefined;
+      args[key] = readArgumentValue(argsRest.slice(valueStart + openValue.length, valueEnd));
+      argsRest = argsRest.slice(valueEnd + closeValue.length);
+    }
+    calls.push({ name, arguments: JSON.stringify(args) });
+  }
+  return calls.length ? calls : undefined;
+}
+
+// Strip every well-formed leaked span from a complete string and return the
+// calls it carried. Returns undefined when the text carries no recoverable
+// call, so callers can relay the original untouched.
+export function parseLeakedToolCalls(text) {
+  if (typeof text !== "string" || !text.includes(OPEN_MARKER)) return undefined;
+  const calls = [];
+  let cleaned = "";
+  let rest = text;
+  for (;;) {
+    const at = rest.indexOf(OPEN_MARKER);
+    if (at === -1) {
+      cleaned += rest;
+      break;
+    }
+    const head = OPEN_RE.exec(rest.slice(at));
+    if (!head) {
+      // `<tool_calls:` without a well-formed nonce and `>`: ordinary text.
+      cleaned += rest.slice(0, at + OPEN_MARKER.length);
+      rest = rest.slice(at + OPEN_MARKER.length);
+      continue;
+    }
+    const closeTag = `</tool_calls:${head[1]}>`;
+    const closeAt = rest.indexOf(closeTag, at + head[0].length);
+    if (closeAt === -1) {
+      // Unterminated: relay what the model actually wrote.
+      cleaned += rest;
+      break;
+    }
+    const parsed = parseSpanBody(rest.slice(at + head[0].length, closeAt), head[1]);
+    if (!parsed) {
+      cleaned += rest.slice(0, closeAt + closeTag.length);
+      rest = rest.slice(closeAt + closeTag.length);
+      continue;
+    }
+    cleaned += rest.slice(0, at);
+    calls.push(...parsed);
+    rest = rest.slice(closeAt + closeTag.length);
+  }
+  if (!calls.length) return undefined;
+  // The markup follows the model's last sentence; drop the gap it left behind.
+  return { cleaned: cleaned.replace(/\s+$/, ""), calls };
+}
+
+// Incremental stripper for one output item's delta channel. `feed` returns the
+// text safe to emit so far and `flush` whatever remains, so a span split across
+// deltas is never relayed as visible text. Recovered calls accumulate in
+// `calls`.
+class LeakedSpanStream {
+  calls = [];
+  #mode = "normal";
+  #carry = "";
+  #captured = "";
+  #bailed = false;
+
+  // Longest suffix of `s` that could still become an opening marker.
+  #partialHold(s) {
+    const max = Math.min(s.length, OPEN_MARKER.length - 1);
+    for (let k = max; k >= 1; k--) {
+      if (OPEN_MARKER.startsWith(s.slice(s.length - k))) return k;
+    }
+    return 0;
+  }
+
+  feed(chunk) {
+    if (this.#bailed) return chunk;
+    let out = "";
+    let input = chunk;
+    for (;;) {
+      if (this.#mode === "normal") {
+        this.#carry += input;
+        input = "";
+        const at = this.#carry.indexOf(OPEN_MARKER);
+        if (at === -1) {
+          const hold = this.#partialHold(this.#carry);
+          out += this.#carry.slice(0, this.#carry.length - hold);
+          this.#carry = this.#carry.slice(this.#carry.length - hold);
+          return out;
+        }
+        out += this.#carry.slice(0, at);
+        this.#captured = this.#carry.slice(at);
+        this.#carry = "";
+        this.#mode = "capture";
+        continue;
+      }
+
+      this.#captured += input;
+      input = "";
+      const head = OPEN_RE.exec(this.#captured);
+      if (!head) {
+        // Still short of a decision, unless it can no longer become a marker.
+        if (this.#captured.length < MAX_OPEN_LEN) return out;
+        out += this.#release();
+        continue;
+      }
+      const closeTag = `</tool_calls:${head[1]}>`;
+      const closeAt = this.#captured.indexOf(closeTag, head[0].length);
+      if (closeAt === -1) {
+        if (this.#captured.length > MAX_CAPTURE_BYTES) {
+          this.#bailed = true;
+          out += this.#release();
+          return out;
+        }
+        return out;
+      }
+      const span = this.#captured.slice(0, closeAt + closeTag.length);
+      const remainder = this.#captured.slice(closeAt + closeTag.length);
+      const parsed = parseLeakedToolCalls(span);
+      this.#captured = "";
+      this.#mode = "normal";
+      if (parsed) this.calls.push(...parsed.calls);
+      else out += span;
+      input = remainder;
+    }
+  }
+
+  flush() {
+    const out = this.#release();
+    this.#carry = "";
+    return out;
+  }
+
+  // Return the buffered text to the visible channel and go back to scanning.
+  #release() {
+    const out = this.#carry + this.#captured;
+    this.#carry = "";
+    this.#captured = "";
+    this.#mode = "normal";
+    return out;
+  }
+}
+
+const CRLF_SEP = Buffer.from("\r\n\r\n");
+const LF_SEP = Buffer.from("\n\n");
+
+function fatalUtf8(buffer) {
+  return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(buffer);
+}
+
+function findFrameEnd(buffer) {
+  const crlf = buffer.indexOf(CRLF_SEP);
+  const lf = buffer.indexOf(LF_SEP);
+  if (crlf !== -1 && (lf === -1 || crlf <= lf)) return { index: crlf, separator: CRLF_SEP };
+  if (lf !== -1) return { index: lf, separator: LF_SEP };
+  return undefined;
+}
+
+function eventBlock(block) {
+  const newline = block.includes("\r\n") ? "\r\n" : "\n";
+  const lines = block.split(/\r?\n/);
+  const dataLineIndex = lines.findIndex((line) => line.startsWith("data:"));
+  if (dataLineIndex === -1) return undefined;
+  const dataText = lines[dataLineIndex].slice(5).replace(/^ /, "");
+  if (!dataText) return undefined;
+  if (dataText === "[DONE]") return { lines, dataLineIndex, newline, sentinel: true };
+  try {
+    return { lines, dataLineIndex, newline, event: JSON.parse(dataText) };
+  } catch {
+    return undefined;
+  }
+}
+
+function rewrittenBlock(parsed, event) {
+  const lines = [...parsed.lines];
+  lines[parsed.dataLineIndex] = `data: ${JSON.stringify(event)}`;
+  return lines.join(parsed.newline);
+}
+
+// Clean the text parts a stored item carries, without collecting from it.
+function cleanTextParts(parts, key) {
+  if (!Array.isArray(parts)) return { parts, changed: false, calls: [] };
+  const calls = [];
+  let changed = false;
+  const next = parts.map((part) => {
+    if (typeof part?.[key] !== "string") return part;
+    const parsed = parseLeakedToolCalls(part[key]);
+    if (!parsed) return part;
+    changed = true;
+    calls.push(...parsed.calls);
+    return { ...part, [key]: parsed.cleaned };
+  });
+  return { parts: changed ? next : parts, changed, calls };
+}
+
+const TERMINAL_TYPES = new Set(["response.completed", "response.done"]);
+
+export class LeakedToolCallRecovery extends Transform {
+  #buffer = Buffer.alloc(0);
+  #passthrough = false;
+  #streams = new Map();
+  // Per output index, the signatures already recovered from it. One item's text
+  // reaches this transform up to three times -- as deltas, as the `.done`
+  // snapshot, and inside the stored item -- and each reading is cumulative, so
+  // a reading is taken only for the calls it adds beyond the last one.
+  #collected = new Map();
+  #recovered = [];
+  #injected = false;
+  #lastSequence = 0;
+  #maxOutputIndex = -1;
+  #lineEnding = "\n";
+
+  recoveredCalls() {
+    return this.#recovered.length;
+  }
+
+  _transform(chunk, encoding, callback) {
+    const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding);
+    if (this.#passthrough) {
+      this.push(piece);
+      callback();
+      return;
+    }
+    this.#buffer = this.#buffer.length ? Buffer.concat([this.#buffer, piece]) : piece;
+    this.#emitBlocks(false);
+    callback();
+  }
+
+  _flush(callback) {
+    if (!this.#passthrough) this.#emitBlocks(true);
+    if (this.#buffer.length) this.push(this.#buffer);
+    this.#buffer = Buffer.alloc(0);
+    // A stream that ended without a terminal event still hands Codex the calls
+    // it managed to recover; nothing else in the pipeline can reconstruct them.
+    if (!this.#passthrough) {
+      const trailing = this.#injectionBlocks();
+      if (trailing) this.push(trailing);
+    }
+    callback();
+  }
+
+  #disable(original) {
+    if (original?.length) this.push(original);
+    if (this.#buffer.length) {
+      this.push(this.#buffer);
+      this.#buffer = Buffer.alloc(0);
+    }
+    this.#passthrough = true;
+  }
+
+  #streamFor(index) {
+    const key = Number.isInteger(index) ? index : 0;
+    let stream = this.#streams.get(key);
+    if (!stream) {
+      stream = new LeakedSpanStream();
+      this.#streams.set(key, stream);
+    }
+    return stream;
+  }
+
+  #emitBlocks(flush) {
+    while (this.#buffer.length && !this.#passthrough) {
+      const found = findFrameEnd(this.#buffer);
+      if (!found) {
+        if (!flush) return;
+        const original = this.#buffer;
+        this.#buffer = Buffer.alloc(0);
+        this.#emitFrame(original, Buffer.alloc(0));
+        return;
+      }
+      const block = this.#buffer.subarray(0, found.index);
+      const original = this.#buffer.subarray(0, found.index + found.separator.length);
+      this.#buffer = this.#buffer.subarray(found.index + found.separator.length);
+      this.#emitFrame(original, found.separator, block);
+    }
+  }
+
+  #emitFrame(original, separator, block = original) {
+    let text;
+    try {
+      text = fatalUtf8(block);
+    } catch {
+      // Non-UTF-8 frames are relayed untouched, and recovery stops: a stream
+      // this transform cannot read is one it must not rewrite.
+      this.#disable(original);
+      return;
+    }
+    let rewritten;
+    try {
+      rewritten = this.#rewrite(text, separator);
+    } catch {
+      this.#disable(original);
+      return;
+    }
+    if (rewritten === null) return;
+    if (rewritten.prefix?.length) this.push(rewritten.prefix);
+    if (rewritten.text === text) {
+      this.push(Buffer.from(original));
+      return;
+    }
+    this.push(Buffer.concat([Buffer.from(rewritten.text), separator]));
+  }
+
+  // Returns `{ prefix, text }` for the frame, or null to drop it (a delta whose
+  // whole payload was markup).
+  #rewrite(block, separator) {
+    const parsed = eventBlock(block);
+    if (!parsed) return { text: block };
+    if (separator?.length) this.#lineEnding = separator.length === 4 ? "\r\n" : "\n";
+    if (parsed.sentinel) return { prefix: this.#injectionBlocks(), text: block };
+
+    const event = parsed.event;
+    const type = event?.type;
+    if (Number.isInteger(event?.sequence_number)) {
+      this.#lastSequence = Math.max(this.#lastSequence, event.sequence_number);
+    }
+    if (Number.isInteger(event?.output_index)) {
+      this.#maxOutputIndex = Math.max(this.#maxOutputIndex, event.output_index);
+    }
+
+    if (TERMINAL_TYPES.has(type)) {
+      const prefix = this.#injectionBlocks();
+      if (!this.#recovered.length) return { prefix, text: block };
+      return { prefix, text: rewrittenBlock(parsed, this.#mergeIntoTerminal(event)) };
+    }
+
+    if (
+      (type === "response.reasoning_summary_text.delta" ||
+        type === "response.reasoning_text.delta" ||
+        type === "response.output_text.delta") &&
+      typeof event.delta === "string"
+    ) {
+      const stream = this.#streamFor(event.output_index);
+      const before = stream.calls.length;
+      const cleaned = stream.feed(event.delta);
+      this.#take(event.output_index, stream, before);
+      if (cleaned === event.delta) return { text: block };
+      if (!cleaned.length) return null;
+      return { text: rewrittenBlock(parsed, { ...event, delta: cleaned }) };
+    }
+
+    if (
+      (type === "response.reasoning_summary_text.done" ||
+        type === "response.reasoning_text.done" ||
+        type === "response.output_text.done") &&
+      typeof event.text === "string"
+    ) {
+      const stream = this.#streamFor(event.output_index);
+      const before = stream.calls.length;
+      stream.flush();
+      this.#take(event.output_index, stream, before);
+      // The snapshot repeats the whole item text. Strip the markup here too --
+      // and collect from it when the delta channel never carried it.
+      const result = parseLeakedToolCalls(event.text);
+      if (!result) return { text: block };
+      this.#collect(event.output_index, result.calls);
+      return { text: rewrittenBlock(parsed, { ...event, text: result.cleaned }) };
+    }
+
+    if (type === "response.output_item.done" && event?.item) {
+      const item = this.#cleanItem(event.item, event.output_index);
+      if (item === event.item) return { text: block };
+      return { text: rewrittenBlock(parsed, { ...event, item }) };
+    }
+
+    return { text: block };
+  }
+
+  #cleanItem(item, outputIndex) {
+    if (item?.type === "reasoning") {
+      const summary = cleanTextParts(item.summary, "text");
+      const content = cleanTextParts(item.content, "text");
+      if (!summary.changed && !content.changed) return item;
+      this.#collect(outputIndex, [...summary.calls, ...content.calls]);
+      return { ...item, summary: summary.parts, content: content.parts };
+    }
+    if (item?.type === "message") {
+      const content = cleanTextParts(item.content, "text");
+      if (!content.changed) return item;
+      this.#collect(outputIndex, content.calls);
+      return { ...item, content: content.parts };
+    }
+    return item;
+  }
+
+  #take(outputIndex, stream, before) {
+    if (stream.calls.length === before) return;
+    // Pass the whole run, not the new slice: `#collect` deduplicates by
+    // comparing a reading against what this index already produced.
+    this.#collect(outputIndex, stream.calls);
+  }
+
+  // Take a reading of one output item's calls. A reading that repeats what the
+  // index already produced adds nothing; one that extends it contributes only
+  // the tail. A reading that disagrees with the first is discarded rather than
+  // relayed twice.
+  #collect(outputIndex, calls) {
+    if (!calls.length) return;
+    const key = Number.isInteger(outputIndex) ? outputIndex : 0;
+    const signatures = calls.map((call) => `${call.name}\u0000${call.arguments}`);
+    const seen = this.#collected.get(key) ?? [];
+    let matched = 0;
+    while (matched < seen.length && seen[matched] === signatures[matched]) matched += 1;
+    if (matched !== seen.length) return;
+    const fresh = calls.slice(matched);
+    if (!fresh.length) return;
+    this.#collected.set(key, signatures);
+    this.#recovered.push(
+      ...fresh.map((call) => ({
+        type: "function_call",
+        name: call.name,
+        call_id: `call_router_recovered_${randomUUID().replaceAll("-", "")}`,
+        arguments: call.arguments,
+      })),
+    );
+  }
+
+  // Emit the recovered calls as real output items, once, immediately before the
+  // event that closes the turn.
+  #injectionBlocks() {
+    if (this.#injected || !this.#recovered.length) return undefined;
+    this.#injected = true;
+    const nl = this.#lineEnding;
+    const blocks = [];
+    for (const item of this.#recovered) {
+      const outputIndex = ++this.#maxOutputIndex;
+      const added = {
+        type: "response.output_item.added",
+        sequence_number: ++this.#lastSequence,
+        output_index: outputIndex,
+        item: { ...item, arguments: "" },
+      };
+      const done = {
+        type: "response.output_item.done",
+        sequence_number: ++this.#lastSequence,
+        output_index: outputIndex,
+        item,
+      };
+      for (const event of [added, done]) {
+        blocks.push(
+          Buffer.from(
+            `event: ${event.type}${nl}data: ${JSON.stringify(event)}${nl}${nl}`,
+            "utf8",
+          ),
+        );
+      }
+    }
+    return blocks.length ? Buffer.concat(blocks) : undefined;
+  }
+
+  // Mirror the injected calls into the terminal event's item list so a consumer
+  // that rebuilds the turn from `response.output` sees them too.
+  #mergeIntoTerminal(event) {
+    const output = event?.response?.output;
+    if (!Array.isArray(output)) return event;
+    return {
+      ...event,
+      response: { ...event.response, output: [...output, ...this.#recovered] },
+    };
+  }
+}
+
+export function leakedToolCallRecoveryTransform(contentType = "") {
+  if (!String(contentType).toLowerCase().includes("text/event-stream")) return undefined;
+  return new LeakedToolCallRecovery();
+}

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -57,6 +57,7 @@ import {
   isEmptyCompletionPreludeLimitError,
 } from "./empty-completion-guard.mjs";
 import { itemLifecycleNormalizerTransform } from "./item-lifecycle-normalizer.mjs";
+import { leakedToolCallRecoveryTransform } from "./leaked-tool-call-recovery.mjs";
 import { reasoningTagStripperTransform } from "./reasoning-tag-stripper.mjs";
 import {
   ZaiResponsesCompatTransform,
@@ -4341,6 +4342,17 @@ async function handleResponses(request, response, requestUrl) {
         ? translatedToolMessageCompatTransform(providerForModel(route), contentType)
         : undefined;
       if (translatedToolMessageCompat) transforms.push(translatedToolMessageCompat);
+      // Recover tool calls a routed model wrote as text. Hy4 Preview has a
+      // native `<tool_calls:NONCE>` syntax that some serving stacks fail to
+      // parse, so the calls arrive on the reasoning channel and the turn ends
+      // with an empty assistant message and no `function_call` -- Codex shows
+      // the "Worked for ..." group and no answer at all. Runs before the
+      // namespace transform so a recovered flattened call is restored like any
+      // other. Native streams (no route) never carry the markup.
+      const leakedToolCalls = route
+        ? leakedToolCallRecoveryTransform(contentType)
+        : undefined;
+      if (leakedToolCalls) transforms.push(leakedToolCalls);
       // Restore flattened namespace calls for routed chat-completions providers
       // and pin an omitted spawn_agent model to every routed parent, including
       // providers that already speak Responses. Also inject missing finished-
@@ -4408,11 +4420,12 @@ async function handleResponses(request, response, requestUrl) {
       ) {
         transforms.push(new ResponsesHeartbeatTransform({ intervalMs: GROK_HEARTBEAT_MS }));
       }
-      return { transforms, usageObserver, guard };
+      return { transforms, usageObserver, guard, leakedToolCalls };
     };
     const firstPipeline = createResponsePipeline(upstreamContentType);
     usageTransform = firstPipeline.usageObserver;
     emptyCompletionGuard = firstPipeline.guard;
+    const leakedToolCallRecovery = firstPipeline.leakedToolCalls;
     const relayOpen = Boolean(emptyCompletionGuard);
     let streamedPreludeFailureKind;
     try {
@@ -4442,6 +4455,15 @@ async function handleResponses(request, response, requestUrl) {
       } else {
         throw error;
       }
+    }
+    // A turn that leaked its tool calls as text would otherwise end silently,
+    // so say when the router put them back: without this the only evidence a
+    // recovery happened is the absence of a failure.
+    const recoveredToolCalls = leakedToolCallRecovery?.recoveredCalls() || 0;
+    if (recoveredToolCalls > 0) {
+      console.error(
+        `[codex-router] recovered ${recoveredToolCalls} tool call(s) the model wrote as text model=${requestedModel || "unknown"} provider=${route?.provider || "unknown"}`,
+      );
     }
     usage = usageTransform?.tokenUsage();
     // Time to the first generated token, which is what an output-tokens-per-

--- a/test/chat-reasoning.test.mjs
+++ b/test/chat-reasoning.test.mjs
@@ -13,6 +13,9 @@ import { childOutput, waitForListeners } from "./listener-readiness.mjs";
 test("native chat reasoning stays scoped to established history contracts", () => {
   assert.equal(usesNativeChatReasoning({ requestProfile: "glm-thinking" }), true);
   assert.equal(usesNativeChatReasoning({ requestProfile: "deepseek-thinking" }), true);
+  // Every hy4 route that thinks shares this profile (opencode-go, openrouter,
+  // nano-gpt, nousresearch); commandcode's own shim and clinepass do not.
+  assert.equal(usesNativeChatReasoning({ requestProfile: "hy4-reasoning" }), true);
   assert.equal(usesNativeChatReasoning({
     provider: "commandcode", upstreamModel: "deepseek/deepseek-v4-flash",
   }), true);
@@ -23,6 +26,8 @@ test("native chat reasoning stays scoped to established history contracts", () =
     { provider: "custom", upstreamModel: "deepseek/deepseek-v4-flash" },
     { provider: "commandcode", upstreamModel: "moonshotai/kimi-k2.6" },
     { provider: "commandcode-messages", upstreamModel: "deepseek/deepseek-v4-flash" },
+    { provider: "commandcode", upstreamModel: "tencent/hy4-preview" },
+    { provider: "clinepass", requestProfile: "clinepass", upstreamModel: "tencent/hy4-preview" },
   ]) {
     assert.equal(usesNativeChatReasoning(model), false);
   }

--- a/test/leaked-tool-call-recovery.test.mjs
+++ b/test/leaked-tool-call-recovery.test.mjs
@@ -1,0 +1,461 @@
+import assert from "node:assert/strict";
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import test from "node:test";
+
+import {
+  LeakedToolCallRecovery,
+  leakedToolCallRecoveryTransform,
+  parseLeakedToolCalls,
+} from "../src/leaked-tool-call-recovery.mjs";
+
+const N = "6124c78e";
+
+// Captured verbatim from rollout 01a0924e-de19-7042-9b8b-aef75e701ea9 (opencode-go
+// hy4-preview, 12 September 2026): the turn that ended with "Worked for 3m 58s"
+// and no assistant message at all.
+const LIVE_REASONING =
+  "Boot is running. Let me keep reading the behavior code while it comes up." +
+  `<tool_calls:${N}><tool_call:${N}>exec_command` +
+  `<arg_key:${N}>cmd</arg_key:${N}>` +
+  `<arg_value:${N}>sleep 20; tail -5 .qa/eo-up.log</arg_value:${N}>` +
+  `<arg_key:${N}>workdir</arg_key:${N}>` +
+  `<arg_value:${N}>/Users/ziwenxu/Desktop/Code/EarthOnline</arg_value:${N}>` +
+  `</tool_call:${N}>` +
+  `<tool_call:${N}>exec_command` +
+  `<arg_key:${N}>cmd</arg_key:${N}>` +
+  `<arg_value:${N}>grep -n "turnRate" src/pedestrians.js</arg_value:${N}>` +
+  `<arg_key:${N}>workdir</arg_key:${N}>` +
+  `<arg_value:${N}>/Users/ziwenxu/Desktop/Code/EarthOnline</arg_value:${N}>` +
+  `</tool_call:${N}></tool_calls:${N}>`;
+
+function block(event, sep = "\n\n") {
+  return `event: ${event.type}\ndata: ${JSON.stringify(event)}${sep}`;
+}
+
+async function run(input, { chunkSize = 0 } = {}) {
+  const transform = new LeakedToolCallRecovery();
+  const chunks = [];
+  const sink = new Writable({
+    write(chunk, _e, cb) {
+      chunks.push(Buffer.from(chunk));
+      cb();
+    },
+  });
+  const source = [];
+  if (chunkSize > 0) {
+    const buf = Buffer.from(input);
+    for (let at = 0; at < buf.length; at += chunkSize) {
+      source.push(buf.subarray(at, at + chunkSize));
+    }
+  } else {
+    source.push(Buffer.from(input));
+  }
+  await pipeline(Readable.from(source), transform, sink);
+  return { body: Buffer.concat(chunks).toString("utf8"), transform };
+}
+
+function events(body) {
+  const out = [];
+  for (const chunk of body.split(/\r?\n\r?\n/)) {
+    const line = chunk.split(/\r?\n/).find((l) => l.startsWith("data:"));
+    if (!line) continue;
+    const text = line.slice(5).trim();
+    if (!text || text === "[DONE]") continue;
+    try {
+      out.push(JSON.parse(text));
+    } catch {
+      // not a JSON event
+    }
+  }
+  return out;
+}
+
+function functionCalls(body) {
+  return events(body)
+    .filter((e) => e.type === "response.output_item.done" && e.item?.type === "function_call")
+    .map((e) => ({ name: e.item.name, arguments: e.item.arguments, output_index: e.output_index }));
+}
+
+test("parses the live capture into the two calls the model meant to make", () => {
+  const parsed = parseLeakedToolCalls(LIVE_REASONING);
+  assert.ok(parsed);
+  assert.equal(parsed.cleaned, "Boot is running. Let me keep reading the behavior code while it comes up.");
+  assert.deepEqual(
+    parsed.calls.map((c) => c.name),
+    ["exec_command", "exec_command"],
+  );
+  assert.deepEqual(JSON.parse(parsed.calls[0].arguments), {
+    cmd: "sleep 20; tail -5 .qa/eo-up.log",
+    workdir: "/Users/ziwenxu/Desktop/Code/EarthOnline",
+  });
+  assert.deepEqual(JSON.parse(parsed.calls[1].arguments), {
+    cmd: 'grep -n "turnRate" src/pedestrians.js',
+    workdir: "/Users/ziwenxu/Desktop/Code/EarthOnline",
+  });
+});
+
+test("parses the shape the tool probe captured on the commandcode route", () => {
+  // From the 28 August 2026 agent-check report for commandcode/hy4-preview,
+  // which failed its tool-call check with exactly this text.
+  const parsed = parseLeakedToolCalls(
+    `We need to output:\n\n<tool_calls:${N}><tool_call:${N}>codex_router_probe` +
+      `<arg_key:${N}>value</arg_key:${N}><arg_value:${N}>ok</arg_value:${N}>` +
+      `</tool_call:${N}></tool_calls:${N}>`,
+  );
+  assert.ok(parsed);
+  assert.equal(parsed.cleaned, "We need to output:");
+  assert.equal(parsed.calls.length, 1);
+  assert.equal(parsed.calls[0].name, "codex_router_probe");
+  assert.deepEqual(JSON.parse(parsed.calls[0].arguments), { value: "ok" });
+});
+
+test("text without the markup is left exactly alone", () => {
+  assert.equal(parseLeakedToolCalls("Let me look at the locomotion code."), undefined);
+  assert.equal(parseLeakedToolCalls("a < b and c > d"), undefined);
+  assert.equal(parseLeakedToolCalls(""), undefined);
+  assert.equal(parseLeakedToolCalls(undefined), undefined);
+});
+
+test("malformed markup is never eaten", () => {
+  // Unterminated span.
+  assert.equal(parseLeakedToolCalls(`prose <tool_calls:${N}><tool_call:${N}>x`), undefined);
+  // Nonce mismatch between open and close.
+  assert.equal(
+    parseLeakedToolCalls(`<tool_calls:${N}><tool_call:${N}>x</tool_call:${N}></tool_calls:deadbeef>`),
+    undefined,
+  );
+  // Opening marker without a nonce.
+  assert.equal(parseLeakedToolCalls("<tool_calls:>nope</tool_calls:>"), undefined);
+  // A name that is not a tool name.
+  assert.equal(
+    parseLeakedToolCalls(`<tool_calls:${N}><tool_call:${N}>not a name</tool_call:${N}></tool_calls:${N}>`),
+    undefined,
+  );
+});
+
+test("a declared number or boolean survives, and a command string does not become one", () => {
+  const parsed = parseLeakedToolCalls(
+    `<tool_calls:${N}><tool_call:${N}>exec_command` +
+      `<arg_key:${N}>timeout_ms</arg_key:${N}><arg_value:${N}>20000</arg_value:${N}>` +
+      `<arg_key:${N}>login</arg_key:${N}><arg_value:${N}>true</arg_value:${N}>` +
+      `<arg_key:${N}>cmd</arg_key:${N}><arg_value:${N}>chmod 0755 run.sh</arg_value:${N}>` +
+      `</tool_call:${N}></tool_calls:${N}>`,
+  );
+  assert.deepEqual(JSON.parse(parsed.calls[0].arguments), {
+    timeout_ms: 20000,
+    login: true,
+    cmd: "chmod 0755 run.sh",
+  });
+});
+
+test("the dead turn now ends with the model's two calls", async () => {
+  const stream =
+    block({ type: "response.created", sequence_number: 1, response: { id: "resp_1" } }) +
+    block({
+      type: "response.output_item.added",
+      sequence_number: 2,
+      output_index: 0,
+      item: { type: "reasoning", id: "rs_1", summary: [] },
+    }) +
+    block({
+      type: "response.reasoning_summary_text.delta",
+      sequence_number: 3,
+      output_index: 0,
+      delta: LIVE_REASONING,
+    }) +
+    block({
+      type: "response.reasoning_summary_text.done",
+      sequence_number: 4,
+      output_index: 0,
+      text: LIVE_REASONING,
+    }) +
+    block({
+      type: "response.output_item.done",
+      sequence_number: 5,
+      output_index: 0,
+      item: { type: "reasoning", id: "rs_1", summary: [{ type: "summary_text", text: LIVE_REASONING }] },
+    }) +
+    block({
+      type: "response.output_item.added",
+      sequence_number: 6,
+      output_index: 1,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [] },
+    }) +
+    block({
+      type: "response.output_item.done",
+      sequence_number: 7,
+      output_index: 1,
+      item: { type: "message", id: "msg_1", role: "assistant", content: [] },
+    }) +
+    block({
+      type: "response.completed",
+      sequence_number: 8,
+      response: {
+        id: "resp_1",
+        output: [
+          { type: "reasoning", id: "rs_1" },
+          { type: "message", id: "msg_1", content: [] },
+        ],
+      },
+    });
+
+  const { body, transform } = await run(stream);
+  const calls = functionCalls(body);
+  assert.equal(transform.recoveredCalls(), 2);
+  assert.equal(calls.length, 2);
+  assert.deepEqual(
+    calls.map((c) => c.name),
+    ["exec_command", "exec_command"],
+  );
+  assert.deepEqual(JSON.parse(calls[0].arguments), {
+    cmd: "sleep 20; tail -5 .qa/eo-up.log",
+    workdir: "/Users/ziwenxu/Desktop/Code/EarthOnline",
+  });
+  // Fresh, unique call ids so replayed history never collides.
+  const ids = events(body)
+    .filter((e) => e.item?.type === "function_call")
+    .map((e) => e.item.call_id);
+  assert.equal(new Set(ids).size, 2);
+  for (const id of ids) assert.match(id, /^call_router_recovered_[0-9a-f]{32}$/);
+
+  // Both calls sit ahead of the terminal event and are mirrored into its output.
+  const types = events(body).map((e) => e.type);
+  const completedAt = types.indexOf("response.completed");
+  const lastCallAt = types.lastIndexOf("response.output_item.done");
+  assert.ok(lastCallAt < completedAt);
+  const completed = events(body).find((e) => e.type === "response.completed");
+  assert.deepEqual(
+    completed.response.output.filter((i) => i.type === "function_call").map((i) => i.name),
+    ["exec_command", "exec_command"],
+  );
+  // They come after the items that were already open, on their own indices.
+  assert.deepEqual(
+    calls.map((c) => c.output_index),
+    [2, 3],
+  );
+});
+
+test("the markup never reaches the client as reasoning text", async () => {
+  const stream =
+    block({ type: "response.reasoning_summary_text.delta", output_index: 0, delta: LIVE_REASONING }) +
+    block({ type: "response.reasoning_summary_text.done", output_index: 0, text: LIVE_REASONING }) +
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "reasoning", summary: [{ type: "summary_text", text: LIVE_REASONING }] },
+    }) +
+    block({ type: "response.completed", response: { id: "r", output: [] } });
+  const { body } = await run(stream);
+  assert.ok(!body.includes("tool_calls:"));
+  assert.ok(!body.includes("arg_key"));
+  assert.ok(body.includes("Let me keep reading the behavior code"));
+});
+
+test("one item's calls are recovered once, however many channels repeat its text", async () => {
+  // delta + done snapshot + stored item all carry the same span.
+  const stream =
+    block({ type: "response.reasoning_summary_text.delta", output_index: 0, delta: LIVE_REASONING }) +
+    block({ type: "response.reasoning_summary_text.done", output_index: 0, text: LIVE_REASONING }) +
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "reasoning", summary: [{ type: "summary_text", text: LIVE_REASONING }] },
+    }) +
+    block({ type: "response.completed", response: { id: "r", output: [] } });
+  const { body, transform } = await run(stream);
+  assert.equal(transform.recoveredCalls(), 2);
+  assert.equal(functionCalls(body).length, 2);
+});
+
+test("a span split across deltas is recovered, at every chunk size", async () => {
+  const head = LIVE_REASONING.slice(0, 90);
+  const mid = LIVE_REASONING.slice(90, 200);
+  const tail = LIVE_REASONING.slice(200);
+  const stream =
+    block({ type: "response.reasoning_summary_text.delta", output_index: 0, delta: head }) +
+    block({ type: "response.reasoning_summary_text.delta", output_index: 0, delta: mid }) +
+    block({ type: "response.reasoning_summary_text.delta", output_index: 0, delta: tail }) +
+    block({ type: "response.completed", response: { id: "r", output: [] } });
+  for (const chunkSize of [0, 1, 7, 64, 4096]) {
+    const { body } = await run(stream, { chunkSize });
+    const calls = functionCalls(body);
+    assert.equal(calls.length, 2, `chunkSize=${chunkSize}`);
+    assert.ok(!body.includes("arg_key"), `chunkSize=${chunkSize}`);
+    assert.ok(body.includes("Boot is running."), `chunkSize=${chunkSize}`);
+  }
+});
+
+test("the same leak on the content channel is recovered too", async () => {
+  const stream =
+    block({ type: "response.output_text.delta", output_index: 0, delta: LIVE_REASONING }) +
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "message", role: "assistant", content: [{ type: "output_text", text: LIVE_REASONING }] },
+    }) +
+    block({ type: "response.completed", response: { id: "r", output: [] } });
+  const { body } = await run(stream);
+  assert.equal(functionCalls(body).length, 2);
+  const message = events(body).find((e) => e.item?.type === "message");
+  assert.equal(
+    message.item.content[0].text,
+    "Boot is running. Let me keep reading the behavior code while it comes up.",
+  );
+});
+
+test("a clean stream is relayed byte-for-byte", async () => {
+  const stream =
+    block({ type: "response.created", sequence_number: 1, response: { id: "r" } }) +
+    block({ type: "response.output_text.delta", output_index: 0, delta: "Paris" }) +
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "message", content: [{ type: "output_text", text: "Paris" }] },
+    }) +
+    block({
+      type: "response.completed",
+      response: { id: "r", output: [{ type: "message", content: [] }] },
+    }) +
+    "data: [DONE]\n\n";
+  for (const chunkSize of [0, 1, 13, 512]) {
+    const { body, transform } = await run(stream, { chunkSize });
+    assert.equal(body, stream, `chunkSize=${chunkSize}`);
+    assert.equal(transform.recoveredCalls(), 0);
+  }
+});
+
+test("a real function_call stream is untouched", async () => {
+  const stream =
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "function_call", name: "exec_command", call_id: "c1", arguments: '{"cmd":"ls"}' },
+    }) +
+    block({ type: "response.completed", response: { id: "r", output: [] } });
+  const { body, transform } = await run(stream);
+  assert.equal(body, stream);
+  assert.equal(transform.recoveredCalls(), 0);
+});
+
+test("CRLF framing is preserved", async () => {
+  const stream =
+    block({ type: "response.reasoning_summary_text.done", output_index: 0, text: LIVE_REASONING }, "\r\n\r\n") +
+    block({ type: "response.completed", response: { id: "r", output: [] } }, "\r\n\r\n");
+  const { body } = await run(stream);
+  assert.equal(functionCalls(body).length, 2);
+  assert.ok(!body.includes("\n\n\n"));
+  assert.ok(body.includes("\r\n\r\n"));
+});
+
+test("invalid UTF-8 disables rewriting and relays the original bytes", async () => {
+  const head = Buffer.from(
+    block({ type: "response.reasoning_summary_text.done", output_index: 0, text: LIVE_REASONING }),
+  );
+  const bad = Buffer.concat([Buffer.from("data: "), Buffer.from([0xff, 0xfe]), Buffer.from("\n\n")]);
+  const tail = Buffer.from(block({ type: "response.completed", response: { id: "r", output: [] } }));
+  const transform = new LeakedToolCallRecovery();
+  const chunks = [];
+  const sink = new Writable({
+    write(chunk, _e, cb) {
+      chunks.push(Buffer.from(chunk));
+      cb();
+    },
+  });
+  await pipeline(Readable.from([Buffer.concat([head, bad, tail])]), transform, sink);
+  const out = Buffer.concat(chunks);
+  assert.ok(out.includes(Buffer.from([0xff, 0xfe])));
+  assert.ok(out.includes(Buffer.from("response.completed")));
+});
+
+test("the factory only attaches to event streams", () => {
+  assert.equal(leakedToolCallRecoveryTransform("application/json"), undefined);
+  assert.equal(leakedToolCallRecoveryTransform(""), undefined);
+  assert.ok(leakedToolCallRecoveryTransform("text/event-stream; charset=utf-8"));
+});
+
+test("two spans in one item are both recovered, and neither is recovered twice", async () => {
+  const span = (cmd) =>
+    `<tool_calls:${N}><tool_call:${N}>exec_command` +
+    `<arg_key:${N}>cmd</arg_key:${N}><arg_value:${N}>${cmd}</arg_value:${N}>` +
+    `</tool_call:${N}></tool_calls:${N}>`;
+  const whole = `first ${span("ls")} then ${span("pwd")}`;
+  const stream =
+    // The spans arrive in separate deltas, then the snapshot and the stored
+    // item each repeat both.
+    block({ type: "response.reasoning_summary_text.delta", output_index: 0, delta: `first ${span("ls")} then ` }) +
+    block({ type: "response.reasoning_summary_text.delta", output_index: 0, delta: span("pwd") }) +
+    block({ type: "response.reasoning_summary_text.done", output_index: 0, text: whole }) +
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "reasoning", summary: [{ type: "summary_text", text: whole }] },
+    }) +
+    block({ type: "response.completed", response: { id: "r", output: [] } });
+  const { body, transform } = await run(stream);
+  assert.equal(transform.recoveredCalls(), 2);
+  assert.deepEqual(
+    functionCalls(body).map((c) => JSON.parse(c.arguments).cmd),
+    ["ls", "pwd"],
+  );
+});
+
+test("a snapshot that only repeats the deltas adds nothing", async () => {
+  const stream =
+    block({ type: "response.reasoning_summary_text.delta", output_index: 0, delta: LIVE_REASONING }) +
+    block({ type: "response.reasoning_summary_text.done", output_index: 0, text: LIVE_REASONING }) +
+    block({ type: "response.completed", response: { id: "r", output: [] } });
+  const { transform } = await run(stream);
+  assert.equal(transform.recoveredCalls(), 2);
+});
+
+test("only the snapshot carries the span when the provider sends no deltas", async () => {
+  const stream =
+    block({ type: "response.reasoning_summary_text.done", output_index: 0, text: LIVE_REASONING }) +
+    block({ type: "response.completed", response: { id: "r", output: [] } });
+  const { body, transform } = await run(stream);
+  assert.equal(transform.recoveredCalls(), 2);
+  assert.equal(functionCalls(body).length, 2);
+});
+
+test("only the stored item carries the span when there is no snapshot either", async () => {
+  const stream =
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "reasoning", summary: [{ type: "summary_text", text: LIVE_REASONING }] },
+    }) +
+    block({ type: "response.completed", response: { id: "r", output: [] } });
+  const { body, transform } = await run(stream);
+  assert.equal(transform.recoveredCalls(), 2);
+  assert.equal(functionCalls(body).length, 2);
+});
+
+test("calls recovered from different items both reach the client", async () => {
+  const stream =
+    block({ type: "response.reasoning_summary_text.done", output_index: 0, text: LIVE_REASONING }) +
+    block({
+      type: "response.output_text.done",
+      output_index: 1,
+      text:
+        `<tool_calls:${N}><tool_call:${N}>update_plan` +
+        `<arg_key:${N}>note</arg_key:${N}><arg_value:${N}>done</arg_value:${N}>` +
+        `</tool_call:${N}></tool_calls:${N}>`,
+    }) +
+    block({ type: "response.completed", response: { id: "r", output: [] } });
+  const { body } = await run(stream);
+  assert.deepEqual(
+    functionCalls(body).map((c) => c.name),
+    ["exec_command", "exec_command", "update_plan"],
+  );
+});
+
+test("a stream that ends without a terminal event still hands over its calls", async () => {
+  const stream = block({
+    type: "response.reasoning_summary_text.done",
+    output_index: 0,
+    text: LIVE_REASONING,
+  });
+  const { body } = await run(stream);
+  assert.equal(functionCalls(body).length, 2);
+});

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -2707,3 +2707,126 @@ test("routed native apply_patch relays LiteLLM arguments that are not a leading 
     assert.equal(closed.item.input, call.input, `${call.id} item input`);
   }
 });
+
+test("a routed turn whose tool calls leaked into the reasoning channel still runs them", async () => {
+  // Captured from rollout 01a0924e (opencode-go hy4-preview, 12 September 2026):
+  // the model wrote its calls as text on the reasoning channel, nothing reached
+  // the tool_calls array, and Codex ended the turn on an empty assistant
+  // message -- "Worked for 3m 58s" with no answer under it.
+  const n = "6124c78e";
+  const leaked =
+    "Boot is running. Let me keep reading the behavior code while it comes up." +
+    `<tool_calls:${n}><tool_call:${n}>exec_command` +
+    `<arg_key:${n}>cmd</arg_key:${n}><arg_value:${n}>tail -5 .qa/eo-up.log</arg_value:${n}>` +
+    `<arg_key:${n}>workdir</arg_key:${n}><arg_value:${n}>/tmp/eo</arg_value:${n}>` +
+    `</tool_call:${n}></tool_calls:${n}>`;
+  const emptyMessage = {
+    id: "msg_blank",
+    type: "message",
+    role: "assistant",
+    status: "completed",
+    content: [],
+  };
+  const result = await scenario(true, {
+    model: "opencode-go/deepseek-v4.1-flash",
+    sseBody: () => [
+      sseEvent({ type: "response.created", response: { id: "resp_leak" } }),
+      sseEvent({
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { type: "reasoning", id: "rs_leak", summary: [] },
+      }),
+      sseEvent({
+        type: "response.reasoning_summary_text.delta",
+        output_index: 0,
+        item_id: "rs_leak",
+        delta: leaked,
+      }),
+      sseEvent({
+        type: "response.reasoning_summary_text.done",
+        output_index: 0,
+        item_id: "rs_leak",
+        text: leaked,
+      }),
+      sseEvent({
+        type: "response.output_item.done",
+        output_index: 0,
+        item: { type: "reasoning", id: "rs_leak", summary: [{ type: "summary_text", text: leaked }] },
+      }),
+      sseEvent({ type: "response.output_item.added", output_index: 1, item: emptyMessage }),
+      sseEvent({ type: "response.output_item.done", output_index: 1, item: emptyMessage }),
+      sseEvent({ type: "response.completed", response: { id: "resp_leak", output: [] } }),
+      "data: [DONE]\n\n",
+    ].join(""),
+  });
+
+  const calls = [...functionCallsFromSse(result.clientBody).values()];
+  assert.equal(calls.length, 1, "the leaked call reaches Codex as a real tool call");
+  assert.equal(calls[0].name, "exec_command");
+  assert.deepEqual(JSON.parse(calls[0].arguments), {
+    cmd: "tail -5 .qa/eo-up.log",
+    workdir: "/tmp/eo",
+  });
+  // The markup itself never reaches the client, and the reasoning it was buried
+  // in still does.
+  assert.ok(!result.clientBody.includes("arg_key"));
+  assert.ok(!result.clientBody.includes("tool_calls:"));
+  assert.ok(result.clientBody.includes("Let me keep reading the behavior code"));
+  // The recovered call lands before the turn closes, so the blank message is
+  // labelled commentary rather than becoming the turn's final answer.
+  const blank = responseItemsFromSse(result.clientBody)
+    .filter((item) => item.type === "message" && item.id === "msg_blank")
+    .at(-1);
+  assert.equal(blank.phase, "commentary");
+});
+
+test("hy4's prior reasoning is replayed as thinking, never as its own visible prose", async () => {
+  // Rollout 01a0928e (opencode-go hy4-preview, 12 September 2026): once the
+  // model's past reasoning was replayed to it as ordinary assistant text, it
+  // stopped using the reasoning channel (174 reasoning tokens -> 0 at one
+  // step) and looped on its last progress note -- 2, 4, 5, 8, then 16 copies.
+  const history = [
+    { type: "message", role: "user", content: [{ type: "input_text", text: "why is the NPC life awkward?" }] },
+    {
+      type: "reasoning",
+      id: "rs_prior",
+      summary: [{ type: "summary_text", text: "PRIOR_THINKING: look at the locomotion code first." }],
+    },
+    {
+      type: "message",
+      role: "assistant",
+      id: "msg_prior",
+      content: [{ type: "output_text", text: "Let me read the locomotion code." }],
+    },
+    { type: "function_call", name: "exec_command", call_id: "call_prior", arguments: '{"cmd":"ls src"}' },
+    { type: "function_call_output", call_id: "call_prior", output: "pedestrians.js" },
+  ];
+  const outgoingFor = async (model) => {
+    const result = await scenario(true, {
+      model,
+      requestPayload: (stream, slug) => ({ model: slug, stream, input: history }),
+    });
+    return result.gatewayBodies[0];
+  };
+
+  const hy4 = await outgoingFor("opencode-go/hy4-preview");
+  const hy4Assistant = hy4.input.find((item) => item.type === "message" && item.role === "assistant");
+  assert.ok(hy4Assistant, "the assistant turn survives");
+  const hy4Parts = hy4Assistant.content.map((part) => `${part.type}:${part.text}`);
+  assert.deepEqual(hy4Parts, [
+    "thinking:PRIOR_THINKING: look at the locomotion code first.",
+    "output_text:Let me read the locomotion code.",
+  ]);
+  assert.equal(
+    hy4.input.some((item) => item.type === "reasoning"),
+    false,
+    "the carried reasoning item is consumed, so it cannot also become a user message",
+  );
+
+  // A chat route with no thinking contract keeps the old shape: reasoning is
+  // merged as text, since LiteLLM would otherwise drop it.
+  const plain = await outgoingFor("opencode-go/kimi-k2.6");
+  const plainAssistant = plain.input.find((item) => item.type === "message" && item.role === "assistant");
+  assert.equal(plainAssistant.content[0].type, "output_text");
+  assert.equal(plainAssistant.content[0].text, "PRIOR_THINKING: look at the locomotion code first.");
+});

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -5891,7 +5891,7 @@ test("API forwarder routes GLM coding-plan models with thinking enabled", async 
   }
 });
 
-["zai-coding-glm-5-3", "deepseek-v4-flash", "commandcode-deepseek-v4-flash"].forEach((gatewayModel) => test(`API forwarder restores ${gatewayModel} thinking as native reasoning_content`, async () => {
+["zai-coding-glm-5-3", "deepseek-v4-flash", "commandcode-deepseek-v4-flash", "opencode-go-hy4-preview"].forEach((gatewayModel) => test(`API forwarder restores ${gatewayModel} thinking as native reasoning_content`, async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {
     upstreamRequests.push({ url: request.url, headers: request.headers, body: await bodyJson(request) });
@@ -5906,6 +5906,8 @@ test("API forwarder routes GLM coding-plan models with thinking enabled", async 
     DEEPSEEK_API_KEY: "TEST_DEEPSEEK_API_KEY",
     COMMANDCODE_BASE_URL: `http://127.0.0.1:${upstream.port}/provider/v1`,
     COMMAND_CODE_API_KEY: "TEST_COMMANDCODE_API_KEY",
+    OPENCODE_GO_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    OPENCODE_GO_API_KEY: "TEST_OPENCODE_GO_API_KEY",
     CODEX_ROUTER_QUIET: "1",
   });
 
@@ -5949,6 +5951,12 @@ test("API forwarder routes GLM coding-plan models with thinking enabled", async 
       assert.deepEqual(request.thinking, { type: "enabled", clear_thinking: false });
     } else if (gatewayModel === "deepseek-v4-flash") {
       assert.deepEqual(request.thinking, { type: "enabled" });
+    } else if (gatewayModel === "opencode-go-hy4-preview") {
+      // Hy4 has no thinking parameter of its own; the history contract alone
+      // must restore reasoning_content without inventing one. (Rollout
+      // 01a0928e, 12 September 2026: replayed as text, the model looped.)
+      assert.ok(upstreamRequests[0].url.endsWith("/chat/completions"));
+      assert.equal(request.thinking, undefined);
     } else {
       assert.equal(upstreamRequests[0].url, "/provider/v1/chat/completions");
       assert.equal(request.thinking, undefined, "history preservation must not enable a new thinking parameter");


### PR DESCRIPTION
Two failures on `opencode-go/hy4-preview`, both captured from one Codex Desktop session on 12 September 2026, both ending a turn without the answer the model was working toward. They are separable; they share edits only in `AGENTS.md`, `CHANGELOG.md`, and the relay test file.

## 1. Hy4 loops on its own progress notes (`src/chat-reasoning.mjs`, one line)

Rollout `01a0928e`: the same sentence 2, 4, 5, 8, then 16 times per message while Codex showed "Reconnecting". Per-step token usage shows the copies were **generated** (16 copies ≈ 324 output tokens), and `reasoning_output_tokens` went **174 → 0** at the step the repeats began, with the model's thinking appearing inside the visible message.

Cause: `usesNativeChatReasoning` listed GLM and DeepSeek but not `hy4-reasoning`, so `carryReasoningThroughInput` replayed Hy4's prior reasoning as visible `output_text` instead of a `thinking` part the forwarder restores to `reasoning_content`. Reading its own past thinking as prose it once said, the model moved new thinking into the answer channel and looped.

Fix: add the profile to the contract. Covers every hy4 route on it (opencode Go, OpenRouter, NanoGPT, Nous); Command Code's own shim and Cline unchanged.

## 2. A turn dies silently when Hy4 writes its tool calls as text (`src/leaked-tool-call-recovery.mjs`, new)

Rollout `01a0924e`: "Worked for 3m 58s", no message. The final step's reasoning summary ends in the model's own tool-call syntax:

```
<tool_calls:6124c78e><tool_call:6124c78e>exec_command<arg_key:6124c78e>cmd</arg_key:6124c78e><arg_value:6124c78e>sleep 20; tail -5 .qa/eo-up.log</arg_value:6124c78e>…
```

Nothing reached the `tool_calls` array (`output_tokens 333 == reasoning_output_tokens 333`), LiteLLM relayed an empty assistant message with no `function_call`, and Codex wrote `task_complete` with `last_agent_message: null`. The 28 August agent-check report already shows `commandcode/hy4-preview` failing its tool probe on exactly this markup.

Fix: an egress transform that parses the markup back into real `function_call` items, strips it from the text, and emits the calls before the turn closes (mirrored into `response.completed.output`). Constraints: only the model's own calls — malformed, unterminated, or nonce-mismatched spans are relayed verbatim; clean streams pass byte-for-byte; invalid UTF-8 disables rewriting; one item's calls are taken once however many channels repeat its text; the nonce is read from the opening tag, never hardcoded; an argument value is read as JSON only when its text is exactly its own JSON form. Placed before the namespace transform so a recovered flattened call is restored like any other, the empty-completion guard sees content, and the blank message is labelled commentary. A log line names each recovery.

## Verification

- `test/leaked-tool-call-recovery.test.mjs` — 21 cases on the captured bytes: span split across deltas at five chunk sizes, CRLF, dedupe across delta/snapshot/stored-item readings, malformed forms, byte-exact passthrough.
- `test/namespace-relay-routing.test.mjs` — two routed cases through the real pipeline: hy4 reasoning arrives at the gateway as `thinking` (with `opencode-go/kimi-k2.6` as the negative control keeping the old shape); the leaked-call stream comes out with the `exec_command` call and the blank message labelled `commentary`.
- `test/routing.test.mjs` — `opencode-go-hy4-preview` added to "API forwarder restores … thinking as native reasoning_content", proving the second hop.
- `test/chat-reasoning.test.mjs` — scoping test extended (hy4-reasoning in; commandcode/clinepass hy4 still out).
- Regressions green: `routing` (131), `namespace-relay-routing` (33), `empty-completion-router` (39), `deepseek-tool-message-compat` (90), `response-usage` (46), plus the smaller reasoning suites. `scripts-check` passes.

Both fixes are live on the author's install since 07:04 local; neither has yet been observed firing on a real hy4 turn (the leak is intermittent).

## Not in this PR

- `opencode-go/deepseek-v4.1-flash` shows the same repeat symptom with a different missing piece — it stores no reasoning items at all — and its fix is #708.
- The 12 × 502 `provider connection failed before a response was available` from opencode Go in the same session is upstream availability, not router code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
