### PR TITLE
fix(tray): explain why the login-free and signed-routing switches are disabled

### DIFF
--- a/apps/macos/ModelRouterTray/Sources/Localization.swift
+++ b/apps/macos/ModelRouterTray/Sources/Localization.swift
@@ -241,6 +241,8 @@ enum RouterChineseText {
     "Quotas and live activity pinned to the desktop": "将额度和实时活动固定在桌面",
     "Show provider usage and activity status": "显示提供商用量和活动状态",
     "Use Router with ChatGPT": "在 ChatGPT 中使用路由",
+    "Turn off 'Use Router with ChatGPT' first": "请先关闭「在 ChatGPT 中使用路由」",
+    "Turn off 'Use without OpenAI login' first": "请先关闭「不使用 OpenAI 登录」",
     "Share ChatGPT subscription": "共享 ChatGPT 订阅",
     "Sharing status unavailable": "无法读取共享状态",
     "Sharing enabled": "共享已启用",

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -6619,9 +6619,11 @@ private struct TrayView: View {
     .padding(.vertical, 2)
     settingRow(
       title: routerLocalized("Use Router with ChatGPT"),
-      detail: store.signedRoutingEnabled(authoritative: store.signedRouting)
-        ? routerLocalized("Native GPT + external models · task history preserved")
-        : routerLocalized("Keep ChatGPT login and the current task history"),
+      detail: store.loginFreeEnabled(authoritative: store.loginFree)
+        ? routerLocalized("Turn off 'Use without OpenAI login' first")
+        : (store.signedRoutingEnabled(authoritative: store.signedRouting)
+          ? routerLocalized("Native GPT + external models · task history preserved")
+          : routerLocalized("Keep ChatGPT login and the current task history")),
       isOn: Binding(
         get: { store.signedRoutingEnabled(authoritative: store.signedRouting) },
         set: { enabled in store.setSignedRouting(enabled) }
@@ -6676,9 +6678,11 @@ private struct TrayView: View {
     }
     settingRow(
       title: routerLocalized("Use without OpenAI login"),
-      detail: store.loginFreeEnabled(authoritative: store.loginFree)
-        ? routerLocalized("External providers · Codex restarts automatically")
-        : routerLocalized("Use connected models and restart Codex"),
+      detail: store.signedRoutingEnabled(authoritative: store.signedRouting)
+        ? routerLocalized("Turn off 'Use Router with ChatGPT' first")
+        : (store.loginFreeEnabled(authoritative: store.loginFree)
+          ? routerLocalized("External providers · Codex restarts automatically")
+          : routerLocalized("Use connected models and restart Codex")),
       isOn: Binding(
         get: { store.loginFreeEnabled(authoritative: store.loginFree) },
         set: { enabled in store.setLoginFree(enabled) }

--- a/apps/macos/ModelRouterTray/Sources/RouterArabicText.swift
+++ b/apps/macos/ModelRouterTray/Sources/RouterArabicText.swift
@@ -110,6 +110,8 @@ enum RouterArabicText {
     "Quotas and live activity pinned to the desktop": "الحصص والنشاط المباشر مثبّتة على سطح المكتب",
     "Show provider usage and activity status": "إظهار استخدام مزوّد الخدمة وحالة النشاط",
     "Use Router with ChatGPT": "استخدام الموجّه مع ChatGPT",
+    "Turn off 'Use Router with ChatGPT' first": "أوقف «استخدام الموجّه مع ChatGPT» أولاً",
+    "Turn off 'Use without OpenAI login' first": "أوقف «الاستخدام بدون تسجيل الدخول إلى OpenAI» أولاً",
     "Share ChatGPT subscription": "مشاركة اشتراك ChatGPT",
     "Sharing status unavailable": "حالة المشاركة غير متاحة",
     "Sharing enabled": "المشاركة مفعّلة",

--- a/apps/macos/ModelRouterTray/Sources/RouterHindiText.swift
+++ b/apps/macos/ModelRouterTray/Sources/RouterHindiText.swift
@@ -110,6 +110,8 @@ enum RouterHindiText {
     "Quotas and live activity pinned to the desktop": "कोटा और लाइव गतिविधि डेस्कटॉप पर पिन की गई",
     "Show provider usage and activity status": "प्रदाता उपयोग और गतिविधि स्थिति दिखाएँ",
     "Use Router with ChatGPT": "ChatGPT के साथ राउटर का उपयोग करें",
+    "Turn off 'Use Router with ChatGPT' first": "पहले 'ChatGPT के साथ राउटर का उपयोग करें' बंद करें",
+    "Turn off 'Use without OpenAI login' first": "पहले 'OpenAI लॉगिन के बिना उपयोग करें' बंद करें",
     "Share ChatGPT subscription": "ChatGPT सदस्यता साझा करें",
     "Sharing status unavailable": "साझाकरण स्थिति उपलब्ध नहीं है",
     "Sharing enabled": "साझाकरण चालू है",

--- a/apps/macos/ModelRouterTray/Sources/RouterJapaneseText.swift
+++ b/apps/macos/ModelRouterTray/Sources/RouterJapaneseText.swift
@@ -110,6 +110,8 @@ enum RouterJapaneseText {
     "Quotas and live activity pinned to the desktop": "割り当てとライブアクティビティをデスクトップに固定",
     "Show provider usage and activity status": "プロバイダーの使用量とアクティビティ状態を表示",
     "Use Router with ChatGPT": "ChatGPT でルーターを使用",
+    "Turn off 'Use Router with ChatGPT' first": "先に「ChatGPT でルーターを使用」をオフにしてください",
+    "Turn off 'Use without OpenAI login' first": "先に「OpenAI ログインなしで使用」をオフにしてください",
     "Share ChatGPT subscription": "ChatGPT サブスクリプションを共有",
     "Sharing status unavailable": "共有状態を取得できません",
     "Sharing enabled": "共有は有効です",

--- a/apps/macos/ModelRouterTray/Sources/RouterKoreanText.swift
+++ b/apps/macos/ModelRouterTray/Sources/RouterKoreanText.swift
@@ -110,6 +110,8 @@ enum RouterKoreanText {
     "Quotas and live activity pinned to the desktop": "할당량과 실시간 활동을 데스크톱에 고정",
     "Show provider usage and activity status": "제공업체 사용량과 활동 상태 표시",
     "Use Router with ChatGPT": "ChatGPT에서 라우터 사용",
+    "Turn off 'Use Router with ChatGPT' first": "먼저 'ChatGPT에서 라우터 사용'을 끄세요",
+    "Turn off 'Use without OpenAI login' first": "먼저 'OpenAI 로그인 없이 사용'을 끄세요",
     "Share ChatGPT subscription": "ChatGPT 구독 공유",
     "Sharing status unavailable": "공유 상태를 확인할 수 없음",
     "Sharing enabled": "공유가 활성화됨",


### PR DESCRIPTION
## Problem

The two Codex auth-mode switches in the macOS tray disable each other, but a disabled switch gave no reason. With signed routing on, the **Use without OpenAI login** row stayed greyed while its detail line still read "Use connected models and restart Codex" — nothing named the switch holding it off, so the switch reads as broken rather than sequenced (observed on a signed-routing install, where the CLI answers `auth-mode on` with "Turn off signed routing before enabling login-free mode" but the tray never surfaces that because the row is not clickable).

## Change

Each row's detail line now names the prerequisite when it is disabled:

- **Use Router with ChatGPT** (disabled while login-free is on) → "Turn off 'Use without OpenAI login' first"
- **Use without OpenAI login** (disabled while signed routing is on) → "Turn off 'Use Router with ChatGPT' first"

No control-flow change: the fail-closed disable stays, only the explanation is added. Strings added to all five translated dictionaries (zh/ar/hi/ja/ko); English fallback covers anything else.

## Verification

`xcrun swiftc -parse` clean on the six touched Swift files. No behavior tests exist for tray copy; existing suites unaffected (macOS tray has no CI target on this file set).