### PR TITLE
fix: fail over on zai weekly-window and lapsed-package quota refusals

### DIFF
--- a/src/error-translation.mjs
+++ b/src/error-translation.mjs
@@ -70,6 +70,13 @@ const QUOTA_PATTERNS = [
   // Both word orders occur in the wild: "usage limit reached" (zai) and
   // "reached your usage limit" (Kimi).
   /usage limit(?:s)? (?:reached|exceeded|hit)/i,
+  // zai 1310 names a weekly or monthly window without the words "usage" or
+  // "quota": "Weekly/Monthly Limit Exhausted. Your limit will reset at ...".
+  /(?:weekly|monthly|daily)\s+limit\s+exhausted/i,
+  // zai 1309/1314: a lapsed Coding Plan or enterprise package is renewed, not
+  // waited out or re-keyed: "Your GLM Coding Plan package has expired and is
+  // temporarily unavailable. You can resume using it after renewing...".
+  /(?:package|plan|subscription) has expired/i,
   /reached your (?:usage|monthly|daily) limit/i,
   /(?:monthly|daily|plan) usage limit/i,
   /purchase extra usage/i,

--- a/test/model-failover.test.mjs
+++ b/test/model-failover.test.mjs
@@ -100,6 +100,34 @@ test("classifyRoutedFailure recognizes the observed Z.ai five-hour window messag
   });
 });
 
+test("classifyRoutedFailure recognizes the documented Z.ai weekly and monthly window message", () => {
+  // zai 1310: "Weekly/Monthly Limit Exhausted. Your limit will reset at ..." --
+  // a quota window that names neither "usage" nor "quota", so the rest of the
+  // vocabulary does not catch it and the turn keeps its 429 instead of
+  // failing over.
+  const verdict = classifyRoutedFailure({
+    status: 429,
+    bodyText: quotaBody("Weekly Limit Exhausted. Your limit will reset at 2026-08-15 13:00:00."),
+    now: NOW,
+  });
+  assert.equal(verdict.swap, true);
+  assert.equal(verdict.reason, "out_of_usage");
+  assert.ok(verdict.until, "the named reset becomes the cooldown window");
+});
+
+test("classifyRoutedFailure swaps on a lapsed Z.ai coding or enterprise package", () => {
+  // zai 1309/1314: renewal restores access -- time does not, and neither does a
+  // fresh key. Still an exhausted plan every other provider can answer.
+  const verdict = classifyRoutedFailure({
+    status: 429,
+    bodyText: quotaBody(
+      "Your GLM Coding Plan package has expired and is temporarily unavailable. You can resume using it after renewing the subscription.",
+    ),
+    now: NOW,
+  });
+  assert.deepEqual(verdict, { swap: true, reason: "out_of_usage" });
+});
+
 test("classifyRoutedFailure honours a reset time the provider named in the body", () => {
   // Z.ai sends no `Retry-After`; the window is a sentence. Without this the
   // exhausted plan was re-attempted on every turn for the whole window.


### PR DESCRIPTION
## Problem

Two documented zai quota refusals classify as neither `out_of_usage` nor anything else, so the turn keeps its 429 instead of failing over to the next enabled model:

- **1310** — `Weekly/Monthly Limit Exhausted. Your limit will reset at {next_flush_time}`: a quota window that names neither `usage` nor `quota`, so `QUOTA_PATTERNS` misses it even though the named reset is exactly the sentence `PROVIDER_NAMED_RESET` already parses.
- **1309 / 1314** — `Your GLM Coding Plan package has expired and is temporarily unavailable. You can resume using it after renewing the subscription…`: renewal fixes it the way a top-up fixes a balance, and no other provider's answer changes, so it belongs to the swap path rather than surfacing as a dead turn.

Wording from the documented error table: https://docs.z.ai/api-reference/api-code

## Change

Two entries in `QUOTA_PATTERNS` (`src/error-translation.mjs`):

- `/(?:weekly|monthly|daily)\s+limit\s+exhausted/i` — 1310. Once classified, the existing `PROVIDER_NAMED_RESET` reads the body's reset stamp into the cooldown window, so the provider is also held off for the window instead of buying the same refusal once per turn.
- `/(?:package|plan|subscription) has expired/i` — 1309/1314. No window is invented: there is no named reset, so the swap carries no `until`.

Neither pattern overlaps `ENTITLEMENT_PATTERNS` (checked first, different vocabulary), and a lapsed package is not an entitlement: the plan did include the API.

## Verification

`node --test` on `model-failover`, `model-failover-router`, `error-translation`, `error-chain`, `rate-limit-quota`: 125 pass, 0 fail, including the two new cases (1310 swap with named window; 1309 swap without one).