### PR TITLE
fix(gemini): safely repair dangling nested tool definitions

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -77,7 +77,6 @@ import {
 } from "./provider-api-key-pool.mjs";
 import {
   inlineDanglingNestedDefsRefs,
-  inlineForeignRefs,
   nonRecursiveToolSchema,
   stripCodexEncryptedSchemaAnnotation,
 } from "./tool-schema-root.mjs";
@@ -395,28 +394,19 @@ function stripEncryptedToolSchemaAnnotations(payload, protocol) {
   if (changed) payload.tools = tools;
 }
 
-// Google's OpenAI-compatible endpoint resolves local JSON-Schema references
-// as definitions, even when the pointer targets an ordinary schema property.
-// Codex connector tools use those property pointers to share nested shapes;
-// Gemini rejects the whole request as an undefined schema before generation.
-// Inline only those foreign pointers. Standard #/$defs references and schemas
-// without a foreign pointer retain their exact wire representation.
-function inlineGeminiToolSchemaRefs(payload, protocol) {
+// The direct Gemini API rejected Zillow's bedrooms schema: its root $defs
+// pointer names a definition stored under request instead. Repair only that
+// malformed-reference class; ordinary property and valid root refs stay intact.
+function inlineGeminiToolSchemaRefs(payload) {
   if (!Array.isArray(payload.tools)) return;
   let changed = false;
   const tools = payload.tools.map((tool) => {
     if (!tool || typeof tool !== "object" || Array.isArray(tool) || tool.type !== "function") {
       return tool;
     }
-    if (protocol === "openai-responses") {
-      const repaired = inlineDanglingNestedDefsRefs(inlineForeignRefs(tool.parameters));
-      if (repaired === tool.parameters) return tool;
-      changed = true;
-      return { ...tool, parameters: repaired };
-    }
     const fn = tool.function;
     if (!fn || typeof fn !== "object" || Array.isArray(fn)) return tool;
-    const repaired = inlineDanglingNestedDefsRefs(inlineForeignRefs(fn.parameters));
+    const repaired = inlineDanglingNestedDefsRefs(fn.parameters);
     if (repaired === fn.parameters) return tool;
     changed = true;
     return { ...tool, function: { ...fn, parameters: repaired } };
@@ -892,8 +882,8 @@ function normalizeBody(buffer, contentType, route) {
   if (model.requestProfile === "codex-encrypted-schema") {
     stripEncryptedToolSchemaAnnotations(payload, provider.protocol);
   }
-  if (isGeminiProvider(provider, model)) {
-    inlineGeminiToolSchemaRefs(payload, provider.protocol);
+  if (provider.id === "gemini-api") {
+    inlineGeminiToolSchemaRefs(payload);
   }
   // Deliberately its own statement rather than a branch of the profile chain
   // below: this is an upstream limitation, and every route that has it also

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -76,6 +76,8 @@ import {
   runProviderApiKeyAttempts,
 } from "./provider-api-key-pool.mjs";
 import {
+  inlineDanglingNestedDefsRefs,
+  inlineForeignRefs,
   nonRecursiveToolSchema,
   stripCodexEncryptedSchemaAnnotation,
 } from "./tool-schema-root.mjs";
@@ -386,6 +388,35 @@ function stripEncryptedToolSchemaAnnotations(payload, protocol) {
     const fn = tool.function;
     if (!fn || typeof fn !== "object" || Array.isArray(fn)) return tool;
     const repaired = stripCodexEncryptedSchemaAnnotation(fn.parameters);
+    if (repaired === fn.parameters) return tool;
+    changed = true;
+    return { ...tool, function: { ...fn, parameters: repaired } };
+  });
+  if (changed) payload.tools = tools;
+}
+
+// Google's OpenAI-compatible endpoint resolves local JSON-Schema references
+// as definitions, even when the pointer targets an ordinary schema property.
+// Codex connector tools use those property pointers to share nested shapes;
+// Gemini rejects the whole request as an undefined schema before generation.
+// Inline only those foreign pointers. Standard #/$defs references and schemas
+// without a foreign pointer retain their exact wire representation.
+function inlineGeminiToolSchemaRefs(payload, protocol) {
+  if (!Array.isArray(payload.tools)) return;
+  let changed = false;
+  const tools = payload.tools.map((tool) => {
+    if (!tool || typeof tool !== "object" || Array.isArray(tool) || tool.type !== "function") {
+      return tool;
+    }
+    if (protocol === "openai-responses") {
+      const repaired = inlineDanglingNestedDefsRefs(inlineForeignRefs(tool.parameters));
+      if (repaired === tool.parameters) return tool;
+      changed = true;
+      return { ...tool, parameters: repaired };
+    }
+    const fn = tool.function;
+    if (!fn || typeof fn !== "object" || Array.isArray(fn)) return tool;
+    const repaired = inlineDanglingNestedDefsRefs(inlineForeignRefs(fn.parameters));
     if (repaired === fn.parameters) return tool;
     changed = true;
     return { ...tool, function: { ...fn, parameters: repaired } };
@@ -860,6 +891,9 @@ function normalizeBody(buffer, contentType, route) {
   }
   if (model.requestProfile === "codex-encrypted-schema") {
     stripEncryptedToolSchemaAnnotations(payload, provider.protocol);
+  }
+  if (isGeminiProvider(provider, model)) {
+    inlineGeminiToolSchemaRefs(payload, provider.protocol);
   }
   // Deliberately its own statement rather than a branch of the profile chain
   // below: this is an upstream limitation, and every route that has it also

--- a/src/tool-schema-root.mjs
+++ b/src/tool-schema-root.mjs
@@ -507,6 +507,100 @@ export function inlineForeignRefs(schema) {
   return inlined;
 }
 
+// Some connector schemas place `$defs` on a nested object while referring to
+// them with a document-root pointer such as `#/$defs/MinMaxInt`. That pointer
+// is invalid JSON Schema, but its intended target is unambiguous when the
+// nearest enclosing `$defs` owns the requested name. Google rejects these as
+// undefined schemas, so inline only those dangling references. Valid root
+// `$defs` refs, ambiguous/missing targets, cycles, and conflicting assertions
+// are left unchanged.
+export function inlineDanglingNestedDefsRefs(schema) {
+  if (!isPlainObject(schema)) return schema;
+  const state = { expansions: 0, exceeded: false, inlined: false };
+  const activeTargets = new WeakSet();
+
+  const visit = (node, scopes, depth) => {
+    if (!isPlainObject(node) || depth > MAX_INLINE_DEPTH || state.exceeded) return node;
+    const nextScopes = isPlainObject(node.$defs) ? [node.$defs, ...scopes] : scopes;
+
+    if (
+      typeof node.$ref === "string" &&
+      node.$ref.startsWith(DEFS_REF_PREFIX) &&
+      resolveRef(node.$ref, schema) === undefined
+    ) {
+      let target;
+      for (const defs of nextScopes) {
+        target = resolveRef(node.$ref, { $defs: defs });
+        if (isPlainObject(target)) break;
+      }
+      if (isPlainObject(target) && !activeTargets.has(target)) {
+        state.expansions += 1;
+        if (state.expansions > MAX_INLINE_EXPANSIONS) {
+          state.exceeded = true;
+          return node;
+        }
+        activeTargets.add(target);
+        const expanded = visit(target, nextScopes, depth);
+        activeTargets.delete(target);
+        const { $ref: _ref, ...siblings } = node;
+        const rewrittenSiblings = visit(siblings, nextScopes, depth);
+        const conflicts = Object.keys(rewrittenSiblings).some((key) => (
+          !REF_OVERRIDE_ANNOTATIONS.has(key) &&
+          Object.hasOwn(expanded, key) &&
+          !isDeepStrictEqual(rewrittenSiblings[key], expanded[key])
+        ));
+        if (!conflicts) {
+          state.inlined = true;
+          return { ...expanded, ...rewrittenSiblings };
+        }
+      }
+    }
+
+    let next = node;
+    const replace = (key, value) => {
+      if (next === node) next = { ...node };
+      next[key] = value;
+    };
+    for (const keyword of [...REF_SCHEMA_MAP_KEYWORDS, "dependencies"]) {
+      const children = node[keyword];
+      if (!isPlainObject(children)) continue;
+      let changed = false;
+      const rewritten = { ...children };
+      for (const [name, child] of Object.entries(children)) {
+        if (!isPlainObject(child)) continue;
+        const repaired = visit(child, nextScopes, depth + 1);
+        if (repaired !== child) {
+          rewritten[name] = repaired;
+          changed = true;
+        }
+      }
+      if (changed) replace(keyword, rewritten);
+    }
+    for (const keyword of [...REF_SCHEMA_ARRAY_KEYWORDS, ...REF_SCHEMA_CHILD_KEYWORDS]) {
+      const children = node[keyword];
+      if (Array.isArray(children)) {
+        let changed = false;
+        const rewritten = children.map((child) => {
+          if (!isPlainObject(child)) return child;
+          const repaired = visit(child, nextScopes, depth + 1);
+          if (repaired !== child) changed = true;
+          return repaired;
+        });
+        if (changed) replace(keyword, rewritten);
+      } else if (isPlainObject(children)) {
+        const repaired = visit(children, nextScopes, depth + 1);
+        if (repaired !== children) replace(keyword, repaired);
+      }
+    }
+    return next;
+  };
+
+  const inlined = visit(schema, [], 0);
+  if (state.exceeded || !state.inlined || inlined === schema) return schema;
+  if (jsonByteLength(inlined) > MAX_INLINE_BYTES) return schema;
+  return inlined;
+}
+
 // Every object-typed leaf reachable from `schema` through unions and local
 // refs. `seen` guards the self-referential `$defs` Codex generates.
 function objectBranches(schema, root, seen, depth = 0) {

--- a/src/tool-schema-root.mjs
+++ b/src/tool-schema-root.mjs
@@ -507,51 +507,93 @@ export function inlineForeignRefs(schema) {
   return inlined;
 }
 
-// Some connector schemas place `$defs` on a nested object while referring to
-// them with a document-root pointer such as `#/$defs/MinMaxInt`. That pointer
-// is invalid JSON Schema, but its intended target is unambiguous when the
-// nearest enclosing `$defs` owns the requested name. Google rejects these as
-// undefined schemas, so inline only those dangling references. Valid root
-// `$defs` refs, ambiguous/missing targets, cycles, and conflicting assertions
-// are left unchanged.
+// Zillow's connector stores MinMaxInt in request.$defs but refers to it as
+// #/$defs/MinMaxInt. Repair missing direct root names using their enclosing
+// definitions, without reinterpreting valid root refs or other pointer forms.
+// This is a compatibility heuristic for malformed schemas, not JSON Schema
+// reference resolution. Resource boundaries, cycles and exhausted budgets
+// return the original schema. Only annotation siblings may be merged.
 export function inlineDanglingNestedDefsRefs(schema) {
   if (!isPlainObject(schema)) return schema;
-  const state = { expansions: 0, exceeded: false, inlined: false };
+  const state = { expansions: 0, nodes: 0, bytes: jsonByteLength(schema), exceeded: false, inlined: false };
+  if (state.bytes > MAX_INLINE_BYTES) return schema;
   const activeTargets = new WeakSet();
+  const contexts = new WeakMap();
 
-  const visit = (node, scopes, depth) => {
-    if (!isPlainObject(node) || depth > MAX_INLINE_DEPTH || state.exceeded) return node;
+  // Index lexical scopes before moving anything. A borrowed definition's own
+  // refs must not bind to same-named definitions at the expansion site.
+  const index = (node, scopes, depth) => {
+    if (state.exceeded) return;
+    state.nodes += 1;
+    if (depth > MAX_INLINE_DEPTH || state.nodes > 8192 || contexts.has(node)) {
+      state.exceeded = true;
+      return;
+    }
+    if (
+      (node !== schema && ["$id", "id", "$schema"].some((key) => Object.hasOwn(node, key))) ||
+      ["$anchor", "$dynamicAnchor", "$dynamicRef", "$recursiveAnchor", "$recursiveRef"]
+        .some((key) => Object.hasOwn(node, key))
+    ) {
+      state.exceeded = true;
+      return;
+    }
     const nextScopes = isPlainObject(node.$defs) ? [node.$defs, ...scopes] : scopes;
+    contexts.set(node, nextScopes);
+    // A null root yields only structural edges, never reference edges.
+    for (const edge of schemaEdges(node, null)) index(edge.node, nextScopes, depth + 1);
+  };
+  index(schema, [], 0);
+  if (state.exceeded) return schema;
+
+  const definitionName = (ref) => {
+    if (typeof ref !== "string") return undefined;
+    let decoded;
+    try { decoded = decodeURIComponent(ref); } catch { return undefined; }
+    const match = /^#\/\$defs\/([^/]+)$/.exec(decoded);
+    if (!match || /~(?:[^01]|$)/.test(match[1])) return undefined;
+    return match[1].replace(/~1/g, "/").replace(/~0/g, "~");
+  };
+
+  const visit = (node, depth) => {
+    if (!isPlainObject(node) || state.exceeded) return node;
+    if (depth > MAX_INLINE_DEPTH) {
+      state.exceeded = true;
+      return node;
+    }
+    const name = definitionName(node.$ref);
 
     if (
-      typeof node.$ref === "string" &&
-      node.$ref.startsWith(DEFS_REF_PREFIX) &&
-      resolveRef(node.$ref, schema) === undefined
+      name !== undefined &&
+      !(isPlainObject(schema.$defs) && Object.hasOwn(schema.$defs, name))
     ) {
       let target;
-      for (const defs of nextScopes) {
-        target = resolveRef(node.$ref, { $defs: defs });
-        if (isPlainObject(target)) break;
+      for (const defs of contexts.get(node) ?? []) {
+        if (!Object.hasOwn(defs, name)) continue;
+        target = defs[name];
+        break;
       }
-      if (isPlainObject(target) && !activeTargets.has(target)) {
+      const { $ref: _ref, ...siblings } = node;
+      // Distinct validation keywords can interact (e.g. properties and
+      // additionalProperties). Even a conflict-free object spread is unsafe.
+      if (isPlainObject(target) && Object.keys(siblings).every((key) => REF_OVERRIDE_ANNOTATIONS.has(key))) {
+        if (activeTargets.has(target)) {
+          state.exceeded = true;
+          return node;
+        }
         state.expansions += 1;
-        if (state.expansions > MAX_INLINE_EXPANSIONS) {
+        // Charge before expansion so repeated large targets cannot allocate a
+        // huge output before the final serialized-size check.
+        state.bytes += jsonByteLength(target);
+        if (state.expansions > MAX_INLINE_EXPANSIONS || state.bytes > MAX_INLINE_BYTES) {
           state.exceeded = true;
           return node;
         }
         activeTargets.add(target);
-        const expanded = visit(target, nextScopes, depth);
+        const expanded = visit(target, depth);
         activeTargets.delete(target);
-        const { $ref: _ref, ...siblings } = node;
-        const rewrittenSiblings = visit(siblings, nextScopes, depth);
-        const conflicts = Object.keys(rewrittenSiblings).some((key) => (
-          !REF_OVERRIDE_ANNOTATIONS.has(key) &&
-          Object.hasOwn(expanded, key) &&
-          !isDeepStrictEqual(rewrittenSiblings[key], expanded[key])
-        ));
-        if (!conflicts) {
+        if (!state.exceeded) {
           state.inlined = true;
-          return { ...expanded, ...rewrittenSiblings };
+          return { ...expanded, ...siblings };
         }
       }
     }
@@ -568,7 +610,7 @@ export function inlineDanglingNestedDefsRefs(schema) {
       const rewritten = { ...children };
       for (const [name, child] of Object.entries(children)) {
         if (!isPlainObject(child)) continue;
-        const repaired = visit(child, nextScopes, depth + 1);
+        const repaired = visit(child, depth + 1);
         if (repaired !== child) {
           rewritten[name] = repaired;
           changed = true;
@@ -582,20 +624,20 @@ export function inlineDanglingNestedDefsRefs(schema) {
         let changed = false;
         const rewritten = children.map((child) => {
           if (!isPlainObject(child)) return child;
-          const repaired = visit(child, nextScopes, depth + 1);
+          const repaired = visit(child, depth + 1);
           if (repaired !== child) changed = true;
           return repaired;
         });
         if (changed) replace(keyword, rewritten);
       } else if (isPlainObject(children)) {
-        const repaired = visit(children, nextScopes, depth + 1);
+        const repaired = visit(children, depth + 1);
         if (repaired !== children) replace(keyword, repaired);
       }
     }
     return next;
   };
 
-  const inlined = visit(schema, [], 0);
+  const inlined = visit(schema, 0);
   if (state.exceeded || !state.inlined || inlined === schema) return schema;
   if (jsonByteLength(inlined) > MAX_INLINE_BYTES) return schema;
   return inlined;

--- a/test/fixtures/gemini-tool-schemas.mjs
+++ b/test/fixtures/gemini-tool-schemas.mjs
@@ -1,0 +1,88 @@
+// Reduced from the cached Zillow connector schema behind the observed Gemini
+// 400 at properties.request.properties.propertyFiltersRequest.properties.bedrooms.
+export function zillowRangeSchema() {
+  return {
+    type: "object",
+    properties: {
+      request: {
+        $defs: {
+          MinMaxInt: {
+            type: "object",
+            properties: {
+              max: { type: "integer", format: "int32", description: "Maximum value" },
+              min: { type: "integer", format: "int32", description: "Minimum value" },
+            },
+          },
+        },
+        type: "object",
+        properties: {
+          propertyFiltersRequest: {
+            type: "object",
+            properties: {
+              bedrooms: {
+                $ref: "#/$defs/MinMaxInt",
+                description: "Bedrooms range filter. Do not add default values if min or max is not specified",
+              },
+            },
+          },
+        },
+      },
+    },
+    required: ["request"],
+  };
+}
+
+export function preservedGeminiSchemas() {
+  return [
+    {
+      name: "valid_boolean_root",
+      schema: {
+        type: "object",
+        $defs: { blocked: false },
+        properties: {
+          request: {
+            type: "object",
+            $defs: { blocked: { type: "string" } },
+            properties: { value: { $ref: "#/$defs/blocked" } },
+          },
+        },
+      },
+    },
+    {
+      name: "embedded_resource",
+      schema: {
+        $id: "https://example.test/root",
+        type: "object",
+        $defs: { value: { type: "string" } },
+        properties: {
+          request: {
+            $id: "https://example.test/request",
+            type: "object",
+            $defs: { value: { type: "integer" } },
+            properties: { value: { $ref: "#/$defs/value", description: "A count" } },
+          },
+        },
+      },
+    },
+    {
+      name: "closed_object",
+      schema: {
+        type: "object",
+        $defs: { closed: { type: "object", additionalProperties: false } },
+        properties: {
+          request: { $ref: "#/$defs/closed", properties: { value: { type: "string" } } },
+        },
+      },
+    },
+    {
+      name: "ordinary_property_pointer",
+      schema: {
+        type: "object",
+        properties: {
+          original: { type: "integer" },
+          alias: { $ref: "#/properties/original", description: "Same type" },
+        },
+      },
+    },
+  ];
+}

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -23,6 +23,7 @@ import {
   LEGACY_V1_SUMMARY_PREFIX,
 } from "../src/compaction-checkpoint.mjs";
 import { openPort } from "./port-pool.mjs";
+import { preservedGeminiSchemas, zillowRangeSchema } from "./fixtures/gemini-tool-schemas.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const INTERNAL_KEY = "test-internal-service-key-with-sufficient-length";
@@ -3772,12 +3773,26 @@ test("API forwarder fills only missing Gemini thought signatures", async () => {
   }
 });
 
-test("API forwarder inlines Gemini property refs that Google treats as undefined schemas", async () => {
+test("API forwarder repairs observed Gemini dangling defs and preserves valid schemas", async () => {
   const upstreamRequests = [];
+  const failureMessage = "reference to undefined schema at properties.request.properties.propertyFiltersRequest.properties.bedrooms";
   const upstream = await mockServer(async (request, response) => {
-    upstreamRequests.push(await bodyJson(request));
+    const body = await bodyJson(request);
+    upstreamRequests.push(body);
+    const bedrooms = body.tools[0].function.parameters.properties.request.properties.propertyFiltersRequest.properties.bedrooms;
+    // Model the recorded rejection, not the full Gemini schema validator.
+    if (bedrooms.$ref) {
+      json(response, 400, { error: { code: 400, message: failureMessage, status: "INVALID_ARGUMENT" } });
+      return;
+    }
     json(response, 200, { choices: [] });
   });
+  const parameters = zillowRangeSchema();
+  const preserved = preservedGeminiSchemas();
+  const tools = [
+    { type: "function", function: { name: "property_search", parameters } },
+    ...preserved.map(({ name, schema }) => ({ type: "function", function: { name, parameters: schema } })),
+  ];
   const curated = curatedGeminiModel();
   const forwarderPort = await openPort();
   const forwarder = run("api-forwarder.mjs", {
@@ -3789,6 +3804,13 @@ test("API forwarder inlines Gemini property refs that Google treats as undefined
   });
 
   try {
+    const baseline = await fetch(`http://127.0.0.1:${upstream.port}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tools }),
+    });
+    assert.equal(baseline.status, 400);
+    assert.equal((await baseline.json()).error.message, failureMessage);
     await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
       Authorization: `Bearer ${INTERNAL_KEY}`,
     });
@@ -3801,58 +3823,20 @@ test("API forwarder inlines Gemini property refs that Google treats as undefined
       body: JSON.stringify({
         model: curated.gatewayModel,
         messages: [{ role: "user", content: "find a home" }],
-        tools: [
-          {
-            type: "function",
-            function: {
-              name: "property_search",
-              parameters: {
-                type: "object",
-                properties: {
-                  request: {
-                    $defs: {
-                      MinMaxInt: {
-                        type: "object",
-                        properties: {
-                          min: { type: "integer" },
-                          max: { type: "integer" },
-                        },
-                      },
-                    },
-                    type: "object",
-                    properties: {
-                      propertyFiltersRequest: {
-                        type: "object",
-                        properties: {
-                          bedrooms: {
-                            $ref: "#/$defs/MinMaxInt",
-                            description: "Bedrooms range filter",
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        ],
+        tools,
       }),
     });
     assert.equal(response.status, 200);
-    const parameters = upstreamRequests[0].tools[0].function.parameters;
-    assert.equal(parameters.properties.request.properties.propertyFiltersRequest.properties.bedrooms.$ref, undefined);
+    const forwarded = upstreamRequests[1].tools[0].function.parameters;
+    assert.equal(forwarded.properties.request.properties.propertyFiltersRequest.properties.bedrooms.$ref, undefined);
     assert.deepEqual(
-      parameters.properties.request.properties.propertyFiltersRequest.properties.bedrooms,
+      forwarded.properties.request.properties.propertyFiltersRequest.properties.bedrooms,
       {
-        type: "object",
-        properties: {
-          min: { type: "integer" },
-          max: { type: "integer" },
-        },
-        description: "Bedrooms range filter",
+        ...parameters.properties.request.$defs.MinMaxInt,
+        description: parameters.properties.request.properties.propertyFiltersRequest.properties.bedrooms.description,
       },
     );
+    assert.deepEqual(upstreamRequests[1].tools.slice(1), tools.slice(1));
   } finally {
     await stopChild(forwarder);
     await closeServer(upstream.server);
@@ -3860,8 +3844,40 @@ test("API forwarder inlines Gemini property refs that Google treats as undefined
   }
 });
 
-test("API forwarder leaves non-Gemini tool calls unsigned", async () => {
+test("Gemini model names on other providers do not enable the schema repair", async () => {
+  const requests = [];
+  const upstream = await mockServer(async (request, response) => {
+    requests.push(await bodyJson(request));
+    json(response, 200, { choices: [] });
+  });
+  const port = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(port),
+    OPENROUTER_API_BASE_URL: `http://127.0.0.1:${upstream.port}/v1`,
+    OPENROUTER_API_KEY: "TEST_OPENROUTER_API_KEY",
+    KIMI_PROXY_QUIET: "1",
+  });
+  const tools = [{ type: "function", function: { name: "property_search", parameters: zillowRangeSchema() } }];
+  try {
+    await waitFor(`http://127.0.0.1:${port}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    const response = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${INTERNAL_KEY}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "openrouter-gemini-3-8-flash", messages: [{ role: "user", content: "test" }], tools }),
+    });
+    assert.equal(response.status, 200);
+    assert.deepEqual(requests[0].tools, tools);
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
+test("API forwarder leaves non-Gemini tool calls unsigned and schemas unchanged", async () => {
   const upstreamRequests = [];
+  const tools = [{ type: "function", function: { name: "a", parameters: zillowRangeSchema() } }];
   const upstream = await mockServer(async (request, response) => {
     upstreamRequests.push(await bodyJson(request));
     json(response, 200, { choices: [] });
@@ -3886,6 +3902,7 @@ test("API forwarder leaves non-Gemini tool calls unsigned", async () => {
       },
       body: JSON.stringify({
         model: "kimi-api-k3",
+        tools,
         messages: [
           { role: "user", content: "test" },
           {
@@ -3904,6 +3921,7 @@ test("API forwarder leaves non-Gemini tool calls unsigned", async () => {
     ).tool_calls;
     assert.equal(call.thought_signature, undefined);
     assert.equal(call.extra_content, undefined);
+    assert.deepEqual(upstreamRequests[0].tools, tools);
   } finally {
     await stopChild(forwarder);
     await closeServer(upstream.server);

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -3772,6 +3772,94 @@ test("API forwarder fills only missing Gemini thought signatures", async () => {
   }
 });
 
+test("API forwarder inlines Gemini property refs that Google treats as undefined schemas", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push(await bodyJson(request));
+    json(response, 200, { choices: [] });
+  });
+  const curated = curatedGeminiModel();
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    MODEL_ROUTER_USER_MODELS: curated.file,
+    GEMINI_API_BASE_URL: `http://127.0.0.1:${upstream.port}/v1`,
+    GEMINI_API_KEY: "TEST_GEMINI_API_KEY",
+    KIMI_PROXY_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    const response = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${INTERNAL_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: curated.gatewayModel,
+        messages: [{ role: "user", content: "find a home" }],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "property_search",
+              parameters: {
+                type: "object",
+                properties: {
+                  request: {
+                    $defs: {
+                      MinMaxInt: {
+                        type: "object",
+                        properties: {
+                          min: { type: "integer" },
+                          max: { type: "integer" },
+                        },
+                      },
+                    },
+                    type: "object",
+                    properties: {
+                      propertyFiltersRequest: {
+                        type: "object",
+                        properties: {
+                          bedrooms: {
+                            $ref: "#/$defs/MinMaxInt",
+                            description: "Bedrooms range filter",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      }),
+    });
+    assert.equal(response.status, 200);
+    const parameters = upstreamRequests[0].tools[0].function.parameters;
+    assert.equal(parameters.properties.request.properties.propertyFiltersRequest.properties.bedrooms.$ref, undefined);
+    assert.deepEqual(
+      parameters.properties.request.properties.propertyFiltersRequest.properties.bedrooms,
+      {
+        type: "object",
+        properties: {
+          min: { type: "integer" },
+          max: { type: "integer" },
+        },
+        description: "Bedrooms range filter",
+      },
+    );
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+    rmSync(curated.dir, { recursive: true, force: true });
+  }
+});
+
 test("API forwarder leaves non-Gemini tool calls unsigned", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { preservedGeminiSchemas, zillowRangeSchema } from "./fixtures/gemini-tool-schemas.mjs";
 
 import { CODEX_APP_TOOLS } from "../src/codex-app-tools.mjs";
 import { toResponsesRequest } from "../src/grok-oauth-forwarder.mjs";
@@ -687,6 +688,165 @@ test("valid root $defs refs and unresolved nested refs stay untouched", () => {
     },
   };
   assert.equal(inlineDanglingNestedDefsRefs(unresolved), unresolved);
+});
+
+test("Gemini repair preserves valid schemas from the adversarial review", () => {
+  for (const { name, schema } of preservedGeminiSchemas()) {
+    const before = structuredClone(schema);
+    assert.equal(inlineDanglingNestedDefsRefs(schema), schema, name);
+    assert.deepEqual(schema, before, name);
+  }
+});
+
+test("Gemini repair preserves the observed Zillow range constraints", () => {
+  const schema = zillowRangeSchema();
+  const before = structuredClone(schema);
+  const repaired = inlineDanglingNestedDefsRefs(schema);
+  assert.deepEqual(repaired.properties.request.properties.propertyFiltersRequest.properties.bedrooms, {
+    ...schema.properties.request.$defs.MinMaxInt,
+    description: schema.properties.request.properties.propertyFiltersRequest.properties.bedrooms.description,
+  });
+  assert.deepEqual(schema, before);
+  assert.equal(inlineDanglingNestedDefsRefs(repaired), repaired);
+});
+
+test("borrowed nested definitions retain their original lexical scope", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      outer: {
+        type: "object",
+        $defs: {
+          Value: { type: "string" },
+          Wrapper: { type: "object", properties: { value: { $ref: "#/$defs/Value" } } },
+        },
+        properties: {
+          inner: {
+            type: "object",
+            $defs: { Value: { type: "integer" } },
+            properties: { wrapper: { $ref: "#/$defs/Wrapper" }, own: { $ref: "#/$defs/Value" } },
+          },
+        },
+      },
+    },
+  };
+  const repaired = inlineDanglingNestedDefsRefs(schema);
+  const outer = repaired.properties.outer;
+  assert.equal(outer.$defs.Wrapper.properties.value.type, "string");
+  assert.equal(outer.properties.inner.properties.wrapper.properties.value.type, "string");
+  assert.equal(outer.properties.inner.properties.own.type, "integer");
+});
+
+test("dangling repair never falls through a boolean or invalid definition", () => {
+  for (const value of [false, true, null, 1]) {
+    const schema = {
+      type: "object",
+      properties: {
+        outer: {
+          $defs: { Value: { type: "string" } },
+          properties: {
+            inner: {
+              $defs: { Value: value },
+              properties: { value: { $ref: "#/$defs/Value" } },
+            },
+          },
+        },
+      },
+    };
+    assert.equal(inlineDanglingNestedDefsRefs(schema), schema);
+    schema.$defs = { Value: value };
+    assert.equal(inlineDanglingNestedDefsRefs(schema), schema);
+  }
+});
+
+test("dangling repair leaves validation siblings intact, including interacting keywords", () => {
+  for (const siblings of [
+    { properties: { value: { type: "string" } } },
+    { additionalProperties: false },
+    { type: "object" },
+    { allOf: [{ minProperties: 1 }] },
+  ]) {
+    const schema = {
+      type: "object",
+      properties: {
+        request: {
+          $defs: { Closed: { type: "object", additionalProperties: false } },
+          properties: { value: { $ref: "#/$defs/Closed", ...siblings } },
+        },
+      },
+    };
+    assert.equal(inlineDanglingNestedDefsRefs(schema), schema);
+  }
+});
+
+test("dangling repair declines resource boundaries and dynamic references", () => {
+  for (const [key, value] of [
+    ["$id", "https://example.test/resource"], ["id", "resource.json"],
+    ["$schema", "https://json-schema.org/draft/2020-12/schema"],
+    ["$anchor", "node"], ["$dynamicRef", "#node"], ["$dynamicAnchor", "node"],
+    ["$recursiveRef", "#"], ["$recursiveAnchor", true],
+  ]) {
+    const schema = zillowRangeSchema();
+    schema.properties.request[key] = value;
+    assert.equal(inlineDanglingNestedDefsRefs(schema), schema, key);
+  }
+});
+
+test("dangling repair decodes pointer names without following other pointer forms", () => {
+  const schema = {
+    properties: {
+      request: {
+        $defs: { "a/b~c": { type: "string" } },
+        properties: {
+          value: { $ref: "#/$defs/a~1b~0c" },
+          encoded: { $ref: "#/%24defs/a~1b~0c" },
+          invalid: { $ref: "#/$defs/a~2b" },
+          malformed: { $ref: "#/$defs/%ZZ" },
+          deeper: { $ref: "#/$defs/a~1b~0c/type" },
+        },
+      },
+    },
+  };
+  const repaired = inlineDanglingNestedDefsRefs(schema).properties.request.properties;
+  assert.deepEqual(repaired.value, { type: "string" });
+  assert.deepEqual(repaired.encoded, { type: "string" });
+  for (const key of ["invalid", "malformed", "deeper"]) {
+    assert.equal(repaired[key], schema.properties.request.properties[key]);
+  }
+});
+
+test("dangling repair leaves literal payloads alone", () => {
+  const schema = zillowRangeSchema();
+  const literal = { $ref: "#/$defs/MinMaxInt", $id: "literal", properties: { nested: { $ref: "#/$defs/MinMaxInt" } } };
+  schema.properties.request.default = literal;
+  schema.properties.request.examples = [literal];
+  const repaired = inlineDanglingNestedDefsRefs(schema);
+  assert.notEqual(repaired, schema);
+  assert.equal(repaired.properties.request.default, literal);
+  assert.equal(repaired.properties.request.examples[0], literal);
+});
+
+test("dangling repair rolls back cycles and expansion, size, and depth limits", () => {
+  for (const defs of [
+    { A: { $ref: "#/$defs/A" } },
+    { A: { $ref: "#/$defs/B" }, B: { $ref: "#/$defs/A" } },
+    { A: { properties: { next: { $ref: "#/$defs/A" } } } },
+  ]) {
+    const schema = { properties: { request: { $defs: defs, properties: { value: { $ref: "#/$defs/A" } } } } };
+    assert.equal(inlineDanglingNestedDefsRefs(schema), schema);
+  }
+  const expanded = zillowRangeSchema();
+  expanded.properties.request.properties = Object.fromEntries(
+    Array.from({ length: 513 }, (_, i) => [`value${i}`, { $ref: "#/$defs/MinMaxInt" }]),
+  );
+  assert.equal(inlineDanglingNestedDefsRefs(expanded), expanded);
+  const large = zillowRangeSchema();
+  large.properties.request.$defs.MinMaxInt.description = "x".repeat(256 * 1024);
+  assert.equal(inlineDanglingNestedDefsRefs(large), large);
+  const deep = zillowRangeSchema();
+  let node = deep;
+  for (let i = 0; i < 40; i += 1) node = node.items = {};
+  assert.equal(inlineDanglingNestedDefsRefs(deep), deep);
 });
 
 test("a $defs ref with sibling keywords is inlined for Moonshot", () => {

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import { CODEX_APP_TOOLS } from "../src/codex-app-tools.mjs";
 import { toResponsesRequest } from "../src/grok-oauth-forwarder.mjs";
 import {
+  inlineDanglingNestedDefsRefs,
   hasObjectRoot,
   inlineForeignRefs,
   nonRecursiveToolSchema,
@@ -632,6 +633,60 @@ test("a $defs ref is the form Moonshot asks for and survives untouched", () => {
   // what it expands to is the `$defs` pointer the property itself carries.
   assert.equal(inlined.properties.alias.$ref, "#/$defs/range");
   assert.deepEqual(inlined.$defs, schema.$defs);
+});
+
+test("a dangling $defs ref resolves from the nearest enclosing schema", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      request: {
+        $defs: {
+          MinMaxInt: {
+            type: "object",
+            properties: { min: { type: "integer" }, max: { type: "integer" } },
+          },
+        },
+        type: "object",
+        properties: {
+          bedrooms: {
+            $ref: "#/$defs/MinMaxInt",
+            description: "Bedrooms range filter.",
+          },
+        },
+      },
+    },
+  };
+  const inlined = inlineDanglingNestedDefsRefs(schema);
+  assert.deepEqual(inlined.properties.request.properties.bedrooms, {
+    type: "object",
+    properties: { min: { type: "integer" }, max: { type: "integer" } },
+    description: "Bedrooms range filter.",
+  });
+  assert.deepEqual(schema.properties.request.properties.bedrooms, {
+    $ref: "#/$defs/MinMaxInt",
+    description: "Bedrooms range filter.",
+  });
+});
+
+test("valid root $defs refs and unresolved nested refs stay untouched", () => {
+  const valid = {
+    type: "object",
+    properties: { value: { $ref: "#/$defs/value" } },
+    $defs: { value: { type: "string" } },
+  };
+  assert.equal(inlineDanglingNestedDefsRefs(valid), valid);
+
+  const unresolved = {
+    type: "object",
+    properties: {
+      request: {
+        $defs: { other: { type: "string" } },
+        type: "object",
+        properties: { value: { $ref: "#/$defs/missing" } },
+      },
+    },
+  };
+  assert.equal(inlineDanglingNestedDefsRefs(unresolved), unresolved);
 });
 
 test("a $defs ref with sibling keywords is inlined for Moonshot", () => {


### PR DESCRIPTION
The direct Gemini API rejected tool-enabled requests because Zillow's connector schema points `bedrooms` at `#/$defs/MinMaxInt`, while `MinMaxInt` is stored under `properties.request.$defs`. This makes the reference undefined at the schema root.

This change repairs missing direct `$defs` names only on the `gemini-api` Chat Completions route. It indexes original definition scopes before inlining, so a borrowed definition cannot acquire a different meaning at its destination. Valid root references (including boolean schemas) and ordinary property pointers remain intact. Only annotation siblings can be merged; validation siblings are left unchanged. Resource boundaries, cycles, and exhausted traversal/expansion/byte budgets return the original schema.

Evidence:

- Local router logs from the reported failure contain repeated upstream HTTP 400 responses for `gemini-api-models-gemini-3-6-flash`: `reference to undefined schema at properties.request.properties.propertyFiltersRequest.properties.bedrooms`, with `INVALID_ARGUMENT` status.
- Inspection of the cached `_zillow_property_search` input schema confirms the misplaced definition. The checked-in fixture is a reduced reproduction of that structure, preserving the actual range types, formats, and descriptions.
- Independently evaluating the full cached schema with Python `jsonschema`'s `Draft202012Validator` raises an unresolved-reference error for `{"request":{"propertyFiltersRequest":{"bedrooms":{"min":1,"max":2}}}}`. The same sample validates with zero errors after repair; the input schema is not mutated.
- [google-gemini/gemini-cli#13326](https://github.com/google-gemini/gemini-cli/issues/13326) is a historical report of the same error class on a different Gemini surface. It corroborates the error class, not this exact route or current API behavior.

Regression coverage exercises the observed malformed schema, valid boolean definitions, embedded resources, interacting `additionalProperties` constraints, shadowed definitions, pointer escaping, literal payloads, and fallback bounds. The forwarding test models the recorded 400, proves the unmodified fixture is rejected, and checks that valid schemas remain unchanged on the wire. Kimi and an OpenRouter-hosted Gemini model retain their original schemas.

Validation:

- `npm run check` passed.
- `node --test --test-timeout=60000 test/routing.test.mjs test/tool-schema-root.test.mjs` passed (191 tests).
- All four standalone adversarial reproductions pass, with independent schema validation for the three valid-schema cases.
- `git diff --check` passed.

The full repository suite and a fresh live Gemini request were not run. The logs establish the historical upstream failure; the local validator and mock demonstrate the repair and forwarding behavior, not current Google API acceptance. General property-reference rewriting and compatibility changes for other providers are outside this PR.
