### PR TITLE
fix: close three review defects in the routed-harness publisher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,11 @@ These instructions apply when a user asks an agent to install this repository.
   (Gemini CLI), `cursor` (Cursor Agent plus Cursor App), and `claude` (Claude
   Code through the router-owned launcher), and `openclaw` (OpenClaw through a
   router-owned Responses provider) are supported
-  targets. OpenCode remains a provider rather than a client target.
+  targets. OpenCode is not a `MODEL_ROUTER_TARGET`: it is both a provider and
+  one of the five *published-into* clients described under "Five clients,
+  one publisher, one key each" below, which `control client-setup` writes a
+  custom provider into rather than installing a target for. A published-into client never gets its
+  own service, state directory, or credential store.
 - Cursor is asymmetric: Cursor Agent uses the router's authenticated loopback
   Connect adapter, while retail Cursor App sends BYOK traffic through Cursor's
   servers and therefore needs an explicit stable public HTTPS tunnel to the

--- a/src/openai-adapters.mjs
+++ b/src/openai-adapters.mjs
@@ -406,8 +406,13 @@ function keepAliveFrame(frame, data) {
 }
 
 function normalizeResponsesEvent(frame, state, flatToNative) {
-  // An SSE comment, or a frame with no data line and no event, is not an event.
-  if (frame.data === "" && !frame.event) return "";
+  // An SSE comment, or a frame with no data line and no event, is not an event
+  // and is not forwarded. It is still proof the upstream was talking, so a
+  // stream that ends before its terminal event is still reported by `flush`.
+  if (frame.data === "" && !frame.event) {
+    state.sawEvent = true;
+    return "";
+  }
   const data = frameData(frame);
   state.sawEvent = true;
   if (state.invalid) return "";

--- a/src/routed-harness-manager.mjs
+++ b/src/routed-harness-manager.mjs
@@ -280,6 +280,7 @@ export function createRoutedHarnessManager(id, {
 
     const target = document();
     const state = readMarker(harness, marker(), port, legacyPort);
+    const documentExisted = existsSync(target);
     const before = readDocument(target);
     assertPublishable(before, state);
 
@@ -322,7 +323,11 @@ export function createRoutedHarnessManager(id, {
       // is the one state neither uninstall nor drift detection can reason
       // about. Put the document back exactly as it was found.
       try {
-        writeDocument(target, before);
+        // "Back" for a client that had no document is absent, not empty: a
+        // zero-byte opencode.json or models.json is not valid JSON, which is
+        // worse for the client than the absence this path exists to restore.
+        if (documentExisted) writeDocument(target, before);
+        else if (existsSync(target)) unlinkSync(target);
       } catch (rollbackError) {
         throw new Error(
           `${redactFailure(error instanceof Error ? error.message : error, secret)} ` +

--- a/test/openai-adapters.test.mjs
+++ b/test/openai-adapters.test.mjs
@@ -207,6 +207,17 @@ test("Responses stream drops a keep-alive after the terminal event instead of fa
   assert.equal(output.some((frame) => frame.event === "error"), false);
 });
 
+test("a stream of nothing but keep-alives still reports an incomplete stream", async () => {
+  // Comments are not forwarded, but they are proof the upstream was talking.
+  // Swallowing them silently would turn a stream that died before its terminal
+  // event into an empty, error-free turn.
+  const output = frames(await transformText(createResponsesStreamTransform(), [
+    ": keep-alive\n\n",
+  ]));
+  assert.equal(output.at(-1).event, "error");
+  assert.equal(output.at(-1).data.code, "upstream_stream_incomplete");
+});
+
 test("Responses provider errors stay structured and do not gain a second terminal frame", async () => {
   const output = frames(await transformText(createResponsesStreamTransform(), [
     "event: error\ndata: {\"type\":\"error\",\"code\":\"provider_failed\",\"message\":\"upstream rejected\"}\n\n",

--- a/test/routed-harness.test.mjs
+++ b/test/routed-harness.test.mjs
@@ -135,8 +135,13 @@ test("a published document is private, because its base URL is the capability", 
   reset();
   for (const harness of routedHarnesses()) {
     manager(harness.id).install();
-    const mode = statSync(DOCUMENTS[harness.id]).mode & 0o777;
-    assert.equal(mode & 0o077, 0, `${harness.id} document is group/other readable`);
+    // Windows carries this as an ACL, not a POSIX mode: Node reports 0o666
+    // there whatever `protectPrivateFile` did. `privateFileIsProtected` is the
+    // check that is meaningful on both, and doctor already runs it.
+    if (process.platform !== "win32") {
+      const mode = statSync(DOCUMENTS[harness.id]).mode & 0o777;
+      assert.equal(mode & 0o077, 0, `${harness.id} document is group/other readable`);
+    }
   }
 });
 
@@ -275,6 +280,23 @@ test("a failed marker write puts the client's document back", () => {
   });
   assert.throws(() => client.install(), /marker write failed/);
   assert.equal(readFileSync(DOCUMENTS.pi, "utf8"), before);
+});
+
+test("a failed first publication leaves no document behind, not an empty one", () => {
+  // Rolling a never-published client "back" to an empty string leaves a
+  // zero-byte opencode.json or models.json, which is not valid JSON and is
+  // worse for the client than the absence this path exists to restore.
+  for (const harness of routedHarnesses()) {
+    reset();
+    assert.equal(existsSync(DOCUMENTS[harness.id]), false);
+    const client = manager(harness.id, {
+      writeMarker: () => {
+        throw new Error("marker write failed");
+      },
+    });
+    assert.throws(() => client.install(), /marker write failed/);
+    assert.equal(existsSync(DOCUMENTS[harness.id]), false, `${harness.id} left a document behind`);
+  }
 });
 
 test("a malformed publication marker refuses to change client state", () => {


### PR DESCRIPTION
Review fixes for #714. Targets that PR's branch so the diff here is just the fix.

### A comment-only Responses stream reported success
`normalizeResponsesEvent` returned before setting `sawEvent`, which is the sole gate on the `upstream_stream_incomplete` error in `flush()`. An upstream that emitted only comments or keep-alives and then EOF'd produced a silent, empty, error-free stream. This is router-wide, not harness-specific: it affects every Responses route.

Comments are still not forwarded — they are just no longer treated as proof that nothing was said.

### A failed first publication left a zero-byte config
Rollback captured `before = readDocument(target)`, which is `""` for a document that does not exist, and wrote that `""` back. Verified on all five clients: after a first-ever publish whose marker write fails, `opencode.json`, `models.json`, `models.yml`, `providers.json` and `config.yaml` all exist at 0 bytes. A zero-byte `opencode.json` is not valid JSON — worse for the client than the absence the rollback exists to restore.

### The privacy assertion read a POSIX mode on Windows
This was the red `test (windows-latest)` check. Node reports `0o666` on Windows whatever `protectPrivateFile` did; protection there is ACL-based via `privateFileIsProtected`. Every other privacy assertion in this repo already guards it (`test/antigravity-oauth-onboarding.test.mjs:440`, `test/control-center-electron.test.mjs:545`).

### Also
`AGENTS.md` still said "OpenCode remains a provider rather than a client target", which this work contradicts. It is a provider *and* a published-into client — not the same thing as a `MODEL_ROUTER_TARGET`.

## Verification
Both source fixes carry a regression test **verified to fail without the corresponding source change**. Reverting the stream fix fails `a stream of nothing but keep-alives still reports an incomplete stream`; reverting the rollback fix fails `a failed first publication leaves no document behind, not an empty one`.

`npm run check` clean. 205/205 pass across `routed-harness`, `openai-adapters`, `client-exports`, `config-manager`, `catalog`, `target-integration`, `control-center-harness`, `caller-key-rotation`, `caller-key-client-refresh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)