### PR TITLE
fix: declare implied tool-schema types for Moonshot routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **Kimi no longer rejects a tool schema whose union leaf declares no type.**
+  A nullable field written the ordinary way --
+  `{"anyOf":[{"type":"string"},{"type":"null"}]}` -- carries no `type` of its
+  own, and Moonshot's validator refuses the whole request with HTTP 400
+  `tools.function.parameters missing type in anyOf properties`, losing the turn
+  on every Kimi model (#641). Nothing in the pipeline supplied one:
+  `normalizeSchemaLiterals` only removes literals that contradict a type a node
+  already declares. The Moonshot compatibility pass now declares a type where
+  the node already implies one -- from `properties`/`required`, `items`, a
+  single-typed `enum`/`const`, or a union whose branches all agree -- alongside
+  the existing `$ref` inlining. A node that implies nothing (a bare `{}`, a
+  lone `not`, a mixed `enum`) is left open, because narrowing a schema the
+  client meant to leave open is worse than the rejection. Every other provider
+  keeps the exact wire payload it has today.
+
 - **A routed model the router has not loaded now fails locally, not at
   ChatGPT.** A model added to or renamed in `user-models.json` shows up in the
   Codex picker as soon as the catalog is rebuilt, but the running router reads

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -8,6 +8,7 @@ import { HeaderlessSseDetector } from "./sse-prefix.mjs";
 import { coerceFunctionCallArguments } from "./tool-arguments.mjs";
 import {
   inlineForeignRefs,
+  declareSchemaTypes,
   nonRecursiveToolSchema,
   providerToolSchema,
 } from "./tool-schema-root.mjs";
@@ -874,7 +875,7 @@ export function jsonArgumentsAreUnambiguous(value, { allowEmpty = false } = {}) 
 // copy.
 export function repairToolSchemaRoot(
   tool,
-  { nonRecursive = false, inlineForeignRefs: inlineRefs = false } = {},
+  { nonRecursive = false, inlineForeignRefs: inlineRefs = false, declareTypes = false } = {},
 ) {
   // Moonshot alone rejects a `$ref` that does not point into `#/$defs/` or one
   // that carries sibling keywords, so only the route that asks for it pays the
@@ -883,7 +884,10 @@ export function repairToolSchemaRoot(
   // is not copied.
   const relaySchema = (schema) => {
     const repaired = providerToolSchema(schema);
-    return inlineRefs ? inlineForeignRefs(repaired) : repaired;
+    const inlined = inlineRefs ? inlineForeignRefs(repaired) : repaired;
+    // After inlining, so a type is declared on the branches a `$ref` brought in
+    // rather than only on the reference that pointed at them.
+    return declareTypes ? declareSchemaTypes(inlined) : inlined;
   };
 
   // Preserve the established shared-provider behavior byte-for-byte. Native

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -3300,7 +3300,7 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
   if (needsMoonshotSchemaCompatibility(route)) {
     // After the namespace flattening above, so the connector tools Codex ships
     // inside `codex_app` are repaired in the shape Moonshot actually receives.
-    tools = repairToolSchemaRoots(tools, { inlineForeignRefs: true });
+    tools = repairToolSchemaRoots(tools, { inlineForeignRefs: true, declareTypes: true });
   }
   let routedInput = input;
   let routedToolChoice = payload.tool_choice;

--- a/src/tool-schema-root.mjs
+++ b/src/tool-schema-root.mjs
@@ -708,6 +708,90 @@ export function normalizeSchemaLiterals(schema, depth = 0) {
   return next;
 }
 
+// Moonshot's validator rejects a schema node that declares no `type` inside a
+// union, naming it as "tools.function.parameters missing type in anyOf
+// properties" (#641). Nothing else in the pipeline supplies one:
+// `normalizeSchemaLiterals` only removes literals that contradict a type a node
+// already declares. A nullable leaf written the ordinary way --
+// `{"anyOf":[{"type":"string"},{"type":"null"}]}` -- therefore reaches Moonshot
+// exactly as the client wrote it and loses the turn.
+//
+// Only declare a type the node already implies. Inferring one from `not`/`if`/
+// `then`/`else`, or guessing for a `$ref` whose target carries the type, would
+// narrow a schema the client meant to leave open, which is worse than the 400.
+// Returns `schema` by identity when every node already says what it is.
+function inferredType(schema) {
+  if ("type" in schema || "$ref" in schema) return undefined;
+  if ("properties" in schema || "required" in schema || "patternProperties" in schema) {
+    return "object";
+  }
+  if ("items" in schema || "prefixItems" in schema) return "array";
+  if (Array.isArray(schema.enum) && schema.enum.length) {
+    const types = [...new Set(schema.enum.map(jsonTypeOf))];
+    if (types.length === 1 && types[0] !== undefined) return types[0];
+    return undefined;
+  }
+  if ("const" in schema) return jsonTypeOf(schema.const);
+  // A union says what it is only when every branch does.
+  for (const keyword of ["anyOf", "oneOf"]) {
+    const branches = schema[keyword];
+    if (!Array.isArray(branches) || !branches.length) continue;
+    const types = [];
+    for (const branch of branches) {
+      if (!isPlainObject(branch)) return undefined;
+      const declared = declaredTypes(branch);
+      if (declared.length !== 1) return undefined;
+      if (!types.includes(declared[0])) types.push(declared[0]);
+    }
+    return types.length === 1 ? types[0] : types;
+  }
+  return undefined;
+}
+
+export function declareSchemaTypes(schema, depth = 0) {
+  if (!isPlainObject(schema) || depth > MAX_LITERAL_DEPTH) return schema;
+  let next = schema;
+  const replace = (key, value) => {
+    if (next === schema) next = { ...schema };
+    next[key] = value;
+  };
+
+  for (const keyword of SCHEMA_MAP_KEYWORDS) {
+    const node = schema[keyword];
+    if (!isPlainObject(node)) continue;
+    let changed = false;
+    const rewritten = {};
+    for (const [name, child] of Object.entries(node)) {
+      const declared = declareSchemaTypes(child, depth + 1);
+      if (declared !== child) changed = true;
+      rewritten[name] = declared;
+    }
+    if (changed) replace(keyword, rewritten);
+  }
+
+  for (const keyword of [...SCHEMA_LIST_KEYWORDS, ...SCHEMA_CHILD_KEYWORDS]) {
+    const node = schema[keyword];
+    if (Array.isArray(node)) {
+      let changed = false;
+      const rewritten = node.map((child) => {
+        const declared = declareSchemaTypes(child, depth + 1);
+        if (declared !== child) changed = true;
+        return declared;
+      });
+      if (changed) replace(keyword, rewritten);
+      continue;
+    }
+    if (!isPlainObject(node)) continue;
+    const declared = declareSchemaTypes(node, depth + 1);
+    if (declared !== node) replace(keyword, declared);
+  }
+
+  // After the children, so a union reads the types its branches just gained.
+  const inferred = inferredType(next);
+  if (inferred !== undefined) replace("type", inferred);
+  return next;
+}
+
 // The one provider-facing normalization: literals aligned with the type their
 // own node declares, and a union root merged into a plain object. Returns
 // `schema` unchanged when neither applies.

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import { CODEX_APP_TOOLS } from "../src/codex-app-tools.mjs";
 import { toResponsesRequest } from "../src/grok-oauth-forwarder.mjs";
 import {
+  declareSchemaTypes,
   hasObjectRoot,
   inlineForeignRefs,
   nonRecursiveToolSchema,
@@ -834,4 +835,55 @@ test("a schema with no foreign ref keeps identity", () => {
   assert.equal(inlineForeignRefs(schema), schema);
   const notObject = ["not", "a", "schema"];
   assert.equal(inlineForeignRefs(notObject), notObject);
+});
+
+test("a union leaf that declares no type gains the type its branches agree on", () => {
+  // #641: Moonshot answers a typeless node inside a union with
+  // "tools.function.parameters missing type in anyOf properties" and loses the
+  // turn. This is the reporter's exact path.
+  const schema = {
+    type: "object",
+    properties: {
+      icon: {
+        anyOf: [
+          { type: "object", properties: { color: { anyOf: [{ type: "string" }, { type: "null" }] } } },
+          { type: "null" },
+        ],
+      },
+    },
+  };
+  const declared = declareSchemaTypes(schema);
+  assert.deepEqual(declared.properties.icon.anyOf[0].properties.color.type, ["string", "null"]);
+  assert.deepEqual(declared.properties.icon.type, ["object", "null"]);
+  // The union itself is preserved: the type is added alongside, never instead.
+  assert.deepEqual(
+    declared.properties.icon.anyOf[0].properties.color.anyOf,
+    [{ type: "string" }, { type: "null" }],
+  );
+});
+
+test("a type is declared only where the node already implies one", () => {
+  assert.equal(declareSchemaTypes({ items: { type: "string" } }).type, "array");
+  assert.equal(declareSchemaTypes({ properties: {} }).type, "object");
+  assert.equal(declareSchemaTypes({ required: ["a"] }).type, "object");
+  assert.equal(declareSchemaTypes({ enum: ["a", "b"] }).type, "string");
+  assert.equal(declareSchemaTypes({ const: 7 }).type, "integer");
+  for (const open of [
+    {},                                  // deliberately open: narrowing is worse than the 400
+    { not: { type: "string" } },         // a negation says what it is not
+    { enum: ["a", 1] },                  // branches disagree
+    { anyOf: [{ type: "string" }, {}] }, // one branch declares nothing
+    { $ref: "#/$defs/Node" },            // the target carries the type
+  ]) {
+    assert.equal("type" in declareSchemaTypes(open), false, JSON.stringify(open));
+  }
+});
+
+test("a schema that already declares its types is returned by identity", () => {
+  const clean = {
+    type: "object",
+    properties: { a: { type: "string" }, b: { type: "array", items: { type: "number" } } },
+  };
+  assert.equal(declareSchemaTypes(clean), clean);
+  assert.equal(declareSchemaTypes({ type: "object" }).type, "object");
 });


### PR DESCRIPTION
Fixes #641.

Moonshot's validator rejects a schema node that declares no `type` inside a union, answering `tools.function.parameters missing type in anyOf properties` and losing the turn on every Kimi model. A nullable field written the ordinary way has no type of its own, so an unremarkable client schema is enough to trigger it.

## The problem is real

Reproduced offline against current `main` with a synthetic schema matching the reporter's exact error path (`properties.details.properties.icon.anyOf.properties.color`) — no credentials, no provider request:

```
A. nullable-union leaf inside anyOf
   output      : {"anyOf":[{"type":"string"},{"type":"null"}]}
   has `type`  : false
   identity    : true   <-- the router rewrote nothing at all
```

Nothing in the pipeline supplies one. `normalizeSchemaLiterals` only *removes* literals that contradict a type a node already declares, and `normalizeKimiBody` rewrites `thinking`/`reasoning_effort` without touching `tools`. The schema reaches Moonshot byte-identical to what the client wrote.

## The fix

`declareSchemaTypes` declares a type only where the node **already implies one**:

- `properties` / `required` / `patternProperties` → `object`
- `items` / `prefixItems` → `array`
- a single-typed `enum`, or `const` → that type
- a union whose branches all declare one → their union

A node that implies nothing is left alone — a bare `{}`, a lone `not`, a mixed `enum`, or a `$ref` whose target carries the type. Narrowing a schema the client meant to leave open is worse than the 400 it avoids. Children are walked before parents so a union reads the types its branches just gained.

It runs inside the existing Moonshot compatibility pass (`needsMoonshotSchemaCompatibility`), after `inlineForeignRefs` so branches a `$ref` brought in are covered too. **Every other provider keeps the exact wire payload it has today** — `repairToolSchemaRoot` without `declareTypes` returns the tool by identity, which is asserted.

## Known related gap, not fixed here

`nonRecursiveToolSchema` breaks a `$ref` cycle by deleting the `$ref` and leaving `{}` behind, so the router can itself produce a typeless node. That runs in `api-forwarder.mjs` — downstream of this pass and unconditional across providers — so it needs its own seam rather than being folded in here. Split out as #726 rather than widened into this change.

## Verification

`npm run check` clean. `routing` 132/132. 223/223 across `tool-schema-root`, `namespace-relay`, `namespace-relay-custom`, `namespace-relay-routing`, `kimi-oauth-forwarder`, `qwen-plan-namespace-restoration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
