### PR TITLE
feat: support Responses WebSocket upgrade instead of 426 fallback

### DIFF
--- a/src/router.mjs
+++ b/src/router.mjs
@@ -67,6 +67,7 @@ import {
 import { mergeCodexAppTools } from "./codex-app-tools.mjs";
 import { activityMetadataFromHeaders } from "./codex-session-names.mjs";
 import { translateGatewayError } from "./error-translation.mjs";
+import { acceptWebSocketUpgrade } from "./websocket-server.mjs";
 import { recordUsageEvent } from "./usage-events.mjs";
 import {
   classifySsePrefix,
@@ -1728,6 +1729,86 @@ function writeIdleNoProviderError(response) {
   });
 }
 
+// Bridge a Codex Responses WebSocket message into the HTTP request pipeline.
+// The WebSocket carries one JSON request body per message; the SSE response
+// stream is relayed back as WebSocket text frames (one frame per SSE chunk).
+async function handleWebSocketResponses(ws, upgradeRequest, message) {
+  const body = Buffer.isBuffer(message) ? message : Buffer.from(message, "utf8");
+  const requestUrl = new URL(
+    upgradeRequest.url || "/",
+    `http://${upgradeRequest.headers.host || LISTEN_HOST}`,
+  );
+  const route = authenticatedRoute(requestUrl.pathname, CALLER_KEY);
+  if (!route) {
+    ws.sendText(
+      `data: ${JSON.stringify({ type: "error", code: "authentication_error", message: "This local router endpoint requires its configured caller capability." })}\n\n`,
+    );
+    ws.close(1008);
+    return;
+  }
+  requestUrl.pathname = route;
+
+  // A minimal fake IncomingMessage exposing only what handleResponses reads.
+  const request = {
+    method: "POST",
+    url: requestUrl.pathname,
+    headers: {
+      ...upgradeRequest.headers,
+      "content-type": "application/json",
+      "content-length": String(body.length),
+    },
+    once() {},
+    on() {},
+    // readRequestBody() iterates the request stream; yield the single body.
+    async *[Symbol.asyncIterator]() {
+      yield body;
+    },
+  };
+
+  // A minimal fake ServerResponse that forwards writes to the WebSocket.
+  // It must be a real Writable: pipeResponse() runs `pipeline(source, ...,
+  // response)` and pipeline requires a stream destination.
+  const { Writable } = await import("node:stream");
+  let headersSent = false;
+  let writableEnded = false;
+  const response = new Writable({
+    write(chunk, _enc, callback) {
+      if (this.destroyed) {
+        callback();
+        return;
+      }
+      const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+      ws.sendText(text);
+      callback();
+    },
+    final(callback) {
+      writableEnded = true;
+      ws.close(1000);
+      callback();
+    },
+  });
+  response.statusCode = 200;
+  response.headersSent = false;
+  response.setHeader = () => {};
+  response.writeHead = (status, headers) => {
+    response.statusCode = status;
+    response.headersSent = true;
+    headersSent = true;
+  };
+  response.on = () => response;
+  response.once = () => response;
+  response.emit = (event, ...args) => {
+    if (event === "close") {
+      // pipeResponse checks response.destroyed on premature close; keep it
+      // consistent with the socket state.
+      if (ws.closed) response.destroyed = true;
+    }
+    return false;
+  };
+
+  await handleResponses(request, response, requestUrl);
+}
+
 async function handleResponses(request, response, requestUrl) {
   const startedAt = Date.now();
   const activity = beginRequestActivity();
@@ -2592,11 +2673,31 @@ const server = http.createServer((request, response) => {
   });
 });
 
-server.on("upgrade", (_request, socket) => {
+server.on("upgrade", (request, socket) => {
   socket.on("error", () => {});
-  socket.end(
-    "HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
-  );
+  // Accept Codex's Responses WebSocket upgrade and relay the request through
+  // the same HTTP pipeline, streaming the SSE response back as WebSocket
+  // text frames. Previously this returned 426 and Codex fell back to HTTP;
+  // supporting the upgrade removes the fallback warning and the extra
+  // connection attempt on every turn.
+  const ws = acceptWebSocketUpgrade(request, socket);
+  if (!ws) return;
+  ws.onMessage = (message) => {
+    handleWebSocketResponses(ws, request, message).catch((error) => {
+      console.error(`[codex-router] websocket request failed: ${formatErrorChain(error)}`);
+      try {
+        ws.sendText(
+          `data: ${JSON.stringify({ type: "error", code: "local_router_error", message: "The local router could not complete the request." })}\n\n`,
+        );
+      } catch {
+        // ignore
+      }
+      ws.close(1011);
+    });
+  };
+  ws.onClose = () => {
+    // nothing to clean up; the request pipeline aborts on socket close
+  };
 });
 // Without this an 'error' event is unhandled and the process exits silently.
 // Under a supervisor that reads as a crash loop with the port never bound and

--- a/src/websocket-server.mjs
+++ b/src/websocket-server.mjs
@@ -1,0 +1,192 @@
+// Minimal RFC 6455 WebSocket server implementation for the codex-router.
+// Purpose: accept Codex's Responses WebSocket upgrade, relay the JSON request
+// body into the existing HTTP request pipeline, and stream the SSE response
+// back as WebSocket text frames.
+//
+// This is intentionally small and dependency-free: the router already ships
+// undici (which has a WebSocket *client* but no server), and adding the `ws`
+// package would put a new dependency on the install path. The protocol subset
+// implemented here covers what Codex's Responses WebSocket client actually
+// sends: masked client frames, text messages, ping/pong, and close.
+
+import { createHash } from "node:crypto";
+
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+// --- Frame encoding (server -> client, unmasked) ---
+
+function encodeFrame(opcode, payload) {
+  const data = Buffer.isBuffer(payload) ? payload : Buffer.from(payload, "utf8");
+  const len = data.length;
+  let header;
+  if (len < 126) {
+    header = Buffer.from([0x80 | opcode, len]);
+  } else if (len < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = 0x80 | opcode;
+    header[1] = 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = 0x80 | opcode;
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+  return Buffer.concat([header, data]);
+}
+
+// --- Frame decoding (client -> server, masked) ---
+
+class FrameDecoder {
+  constructor() {
+    this.buffer = Buffer.alloc(0);
+  }
+
+  push(chunk) {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    return this.tryParse();
+  }
+
+  tryParse() {
+    const buf = this.buffer;
+    if (buf.length < 2) return null;
+    const fin = (buf[0] & 0x80) !== 0;
+    const opcode = buf[0] & 0x0f;
+    const masked = (buf[1] & 0x80) !== 0;
+    let len = buf[1] & 0x7f;
+    let offset = 2;
+    if (len === 126) {
+      if (buf.length < 4) return null;
+      len = buf.readUInt16BE(2);
+      offset = 4;
+    } else if (len === 127) {
+      if (buf.length < 10) return null;
+      const big = buf.readBigUInt64BE(2);
+      if (big > BigInt(Number.MAX_SAFE_INTEGER)) throw new Error("frame too large");
+      len = Number(big);
+      offset = 10;
+    }
+    let maskKey = null;
+    if (masked) {
+      if (buf.length < offset + 4) return null;
+      maskKey = buf.subarray(offset, offset + 4);
+      offset += 4;
+    }
+    if (buf.length < offset + len) return null;
+    let payload = buf.subarray(offset, offset + len);
+    if (masked && maskKey) {
+      const unmasked = Buffer.alloc(len);
+      for (let i = 0; i < len; i++) unmasked[i] = payload[i] ^ maskKey[i % 4];
+      payload = unmasked;
+    }
+    this.buffer = buf.subarray(offset + len);
+    return { fin, opcode, payload };
+  }
+}
+
+// --- Connection wrapper ---
+
+export class WebSocketConnection {
+  constructor(socket, request) {
+    this.socket = socket;
+    this.request = request;
+    this.decoder = new FrameDecoder();
+    this.closed = false;
+    this.onMessage = null;
+    this.onClose = null;
+    this.onError = null;
+
+    socket.on("data", (chunk) => {
+      try {
+        const frame = this.decoder.push(chunk);
+        if (frame) this.handleFrame(frame);
+      } catch (err) {
+        this.fail(err);
+      }
+    });
+    socket.on("error", (err) => {
+      if (this.onError) this.onError(err);
+    });
+    socket.on("close", () => {
+      this.closed = true;
+      if (this.onClose) this.onClose();
+    });
+  }
+
+  handleFrame(frame) {
+    switch (frame.opcode) {
+      case 0x1: // text
+        if (this.onMessage) this.onMessage(frame.payload.toString("utf8"));
+        break;
+      case 0x2: // binary
+        if (this.onMessage) this.onMessage(frame.payload);
+        break;
+      case 0x8: // close
+        this.close(1000);
+        break;
+      case 0x9: // ping
+        this.sendFrame(0xa, frame.payload); // pong
+        break;
+      case 0xa: // pong
+        break;
+      default:
+        break;
+    }
+  }
+
+  sendFrame(opcode, payload) {
+    if (this.closed) return;
+    try {
+      this.socket.write(encodeFrame(opcode, payload));
+    } catch {
+      // socket gone; ignore
+    }
+  }
+
+  sendText(text) {
+    this.sendFrame(0x1, text);
+  }
+
+  close(code = 1000) {
+    if (this.closed) return;
+    try {
+      const payload = Buffer.alloc(2);
+      payload.writeUInt16BE(code, 0);
+      this.socket.write(encodeFrame(0x8, payload));
+    } catch {
+      // ignore
+    }
+    this.closed = true;
+    this.socket.end();
+  }
+
+  fail(err) {
+    if (this.onError) this.onError(err);
+    this.closed = true;
+    this.socket.destroy();
+  }
+}
+
+// --- Handshake ---
+
+export function acceptWebSocketUpgrade(request, socket) {
+  const key = request.headers["sec-websocket-key"];
+  if (!key) {
+    socket.end(
+      "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+    );
+    return null;
+  }
+  const accept = createHash("sha1")
+    .update(key + WS_GUID)
+    .digest("base64");
+  const headers = [
+    "HTTP/1.1 101 Switching Protocols",
+    "Upgrade: websocket",
+    "Connection: Upgrade",
+    `Sec-WebSocket-Accept: ${accept}`,
+    "\r\n",
+  ].join("\r\n");
+  socket.write(headers);
+  return new WebSocketConnection(socket, request);
+}


### PR DESCRIPTION
## Summary

Codex first attempts a **Responses WebSocket** connection to the router on every turn. The router previously declined every upgrade with `HTTP 426 Upgrade Required`, forcing Codex to fall back to compressed HTTP — visible as a persistent `codex doctor` warning (`Responses WebSocket failed; HTTPS fallback may still work`).

This PR makes the router actually accept the upgrade and relay the request through the existing HTTP pipeline.

## Changes

- **`src/websocket-server.mjs`** (new): minimal dependency-free RFC 6455 server — handshake (`Sec-WebSocket-Accept`), masked client frame decoding, text/binary messages, ping/pong, close. Covers exactly what Codex's Responses WebSocket client sends.
- **`src/router.mjs`**: the `server.on("upgrade")` handler now accepts the upgrade instead of returning 426. Each WebSocket message body is bridged into `handleResponses` via a fake `IncomingMessage` (async-iterable body) and a real `stream.Writable` fake `ServerResponse` (required because `pipeResponse` runs `pipeline(source, ..., response)`). The SSE response stream is relayed back as WebSocket text frames.

## Verification

- `codex doctor` now reports `websocket: connected (HTTP 101 Switching Protocols)` (was `failed (HTTP 426)`).
- End-to-end streamed turn over the socket: `response.created` → `response.in_progress` → `response.output_text.delta` → `[DONE]`, then clean close.
- HTTP path unchanged; existing behavior preserved for non-upgrade requests.

## Notes

- No new dependencies (undici ships a WebSocket *client* but no server; adding `ws` would put a new package on the install path).
- The implementation is intentionally minimal — only the frame types Codex actually sends are handled.