### PR TITLE
fix: key harvested quota headers by cooldown scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@
   client meant to leave open is worse than the rejection. Every other provider
   keeps the exact wire payload it has today.
 
+- **opencode Zen's quota headers no longer overwrite the Go plan's.** Both
+  plans share one credential and one selection toggle, but Zen bills at its own
+  endpoint, which is why `cooldownScope` keeps Zen's identity where
+  `canonicalProviderId` folds it into Go. The forwarder harvested the observed
+  rate-limit headers under the canonical id instead, so every Zen response
+  overwrote the Go plan's entry in `rate-limits.json` and every Go response
+  overwrote Zen's -- one key holding whichever plan answered last, under the
+  name of the other. Zen's window could not be read back either: every
+  cooldown-scope consumer looks it up as `opencode-zen`, an id the file never
+  held. The snapshot is now keyed by cooldown scope, the same identity the
+  cooldown store beside it already uses, so the two cannot drift apart again
+  (#575). Every other provider and variant keeps the key it has today, and a
+  stale entry is replaced by the next response that carries headers.
+
 - **A routed model the router has not loaded now fails locally, not at
   ChatGPT.** A model added to or renamed in `user-models.json` shows up in the
   Codex picker as soon as the catalog is rebuilt, but the running router reads

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -38,6 +38,7 @@ import {
 } from "./rate-limit-headers.mjs";
 import { recordRateLimitSnapshot } from "./rate-limit-state.mjs";
 import { recordProviderCooldown } from "./model-failover.mjs";
+import { cooldownScope } from "./provider-cooldown.mjs";
 import { canonicalProviderId, readProviderSelection } from "./provider-selection.mjs";
 import { stripImages, supportsImageInput } from "./vision-bridge.mjs";
 import {
@@ -1223,9 +1224,13 @@ async function upstreamSession(provider, credential, payload, options = {}, endp
 // never sit in time-to-first-byte.
 function recordUpstreamLimits(normalized, upstream) {
   const rateLimit = parseRateLimitHeaders(upstream.headers);
-  // Variant-routed responses meter the same upstream subscription, so quota
-  // headers land under the family's canonical provider id.
-  if (rateLimit) recordRateLimitSnapshot(canonicalProviderId(normalized.provider.id), rateLimit);
+  // Keyed by cooldown scope, the same identity `recordProviderCooldown` uses
+  // below. A protocol variant meters its parent's subscription and shares its
+  // key, but opencode Zen is billed at its own endpoint: canonicalizing here
+  // filed Zen's window under the Go plan, so each plan's response overwrote the
+  // other's snapshot and neither could be read back under the id that produced
+  // it.
+  if (rateLimit) recordRateLimitSnapshot(cooldownScope(normalized.provider.id), rateLimit);
   // This hop is the only place the provider's own status and headers are seen
   // before LiteLLM restates them, so it is the only place a reset time the
   // gateway does not relay can still be read. A failure that names when the

--- a/test/rate-limit-scope.test.mjs
+++ b/test/rate-limit-scope.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { userModelEntry } from "../src/user-models.mjs";
+import { openPort } from "./port-pool.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const INTERNAL_KEY = "rate-limit-scope-internal-key-with-sufficient-length";
+
+async function listen(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return { server, port: server.address().port };
+}
+
+async function waitForHealth(base, headers, child, errors) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`forwarder exited: ${errors()}`);
+    try {
+      if ((await fetch(`${base}/health`, { headers })).ok) return;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 40));
+  }
+  throw new Error(`forwarder never became healthy: ${errors()}`);
+}
+
+// opencode Zen shares Go's credential and selection toggle but bills at its own
+// endpoint, so it is the one provider whose cooldown scope is not its canonical
+// parent. Keying the harvested headers by the parent filed each plan's window
+// under the other and left Zen's own id empty for every reader.
+test("a separately billed variant's quota headers do not overwrite its parent's", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "rate-limit-scope-"));
+  const stateDir = path.join(directory, "state");
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  const userModelsFile = path.join(directory, "user-models.json");
+  const limitsPath = path.join(stateDir, "rate-limits.json");
+
+  // The Go plan's own window, harvested from an earlier Go response.
+  writeFileSync(
+    limitsPath,
+    `${JSON.stringify({
+      "opencode-go": {
+        requests: { limit: 1000, remaining: 900 },
+        observedAt: "2026-09-01T00:00:00.000Z",
+      },
+    }, null, 2)}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+
+  const upstream = await listen((request, response) => {
+    const body = Buffer.from(JSON.stringify({
+      id: "chatcmpl-zen-1",
+      object: "chat.completion",
+      model: "zen-test-model",
+      choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+    }), "utf8");
+    response.writeHead(200, {
+      "Content-Type": "application/json",
+      "Content-Length": String(body.length),
+      "x-ratelimit-limit-requests": "50",
+      "x-ratelimit-remaining-requests": "7",
+      "x-ratelimit-reset-requests": "60s",
+    });
+    response.end(body);
+  });
+
+  const model = userModelEntry({
+    providerId: "opencode-zen",
+    upstreamId: "zen-test-model",
+    priority: 100,
+  });
+  writeFileSync(userModelsFile, `${JSON.stringify({ version: 1, models: [model] }, null, 2)}\n`);
+
+  const forwarderPort = await openPort();
+  const child = spawn(process.execPath, [path.join(root, "src", "api-forwarder.mjs")], {
+    cwd: root,
+    env: {
+      ...process.env,
+      MODEL_ROUTER_TARGET: "codex",
+      MODEL_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
+      MODEL_ROUTER_API_PORT: String(forwarderPort),
+      MODEL_ROUTER_STATE_DIR: stateDir,
+      MODEL_ROUTER_USER_MODELS: userModelsFile,
+      MODEL_ROUTER_QUIET: "1",
+      OPENCODE_ZEN_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+      OPENCODE_API_KEY: "zen-test-key",
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  child.stderr.setEncoding("utf8");
+  let stderr = "";
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  const base = `http://127.0.0.1:${forwarderPort}`;
+  const headers = { Authorization: `Bearer ${INTERNAL_KEY}`, "Content-Type": "application/json" };
+  try {
+    await waitForHealth(base, headers, child, () => stderr);
+    const answer = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: model.gatewayModel,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    const answerBody = await answer.text();
+    assert.equal(answer.status, 200, `zen turn failed: ${answerBody} ${stderr}`);
+
+    // Limits are persisted after the body is piped, so give that write a moment.
+    const deadline = Date.now() + 2_000;
+    let limits;
+    do {
+      limits = JSON.parse(readFileSync(limitsPath, "utf8"));
+      if (limits["opencode-zen"] || limits["opencode-go"]?.requests?.remaining !== 900) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    } while (Date.now() < deadline);
+
+    // Zen's window is filed under the id that produced it, so every reader --
+    // all of which key by cooldown scope -- can find it.
+    assert.equal(limits["opencode-zen"]?.requests?.remaining, 7);
+    assert.equal(limits["opencode-zen"]?.requests?.limit, 50);
+    // And the Go plan's separately billed window is still the Go plan's.
+    assert.equal(limits["opencode-go"]?.requests?.remaining, 900);
+    assert.equal(limits["opencode-go"]?.requests?.limit, 1000);
+  } finally {
+    if (child.exitCode === null) {
+      child.kill("SIGTERM");
+      await new Promise((resolve) => child.once("exit", resolve));
+    }
+    await new Promise((resolve) => upstream.server.close(resolve));
+    rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Why

Follow-up to the second finding in #575, which you asked for as its own change:

> The `cooldownScope` extraction suggests the direction is already "keep the identity, drop the second implementation". If that's right, the `api-forwarder.mjs:1228` one-liner is worth taking on its own so the two stores can't drift back apart — please do send it.

`recordUpstreamLimits` writes to two stores from one provider id, under two different keys:

```js
if (rateLimit) recordRateLimitSnapshot(canonicalProviderId(normalized.provider.id), rateLimit);
...
recordProviderCooldown(normalized.provider.id, { until, reason });   // keys by cooldownScope
```

`opencode-zen` is the one id where those two functions disagree — it is `variantOf: opencode-go`, so `canonicalProviderId` folds it into Go, while `cooldownScope` deliberately keeps it because Zen bills at its own `/zen` endpoint.

Reproduced offline on current `main`, no credentials and no provider request, by calling the two modules the way the forwarder does — the Go plan reports 900 requests left, then a Zen response reports 12:

```
--- today: canonicalProviderId keying ---
rate-limits.json keys: [ 'opencode-go' ]
opencode-go  remaining: 12
opencode-zen remaining: undefined
cooldownScope('opencode-zen') = opencode-zen -> snapshot: MISS
```

Two separately billed plans, one key. Zen's number is sitting under the Go plan's name, and the Go plan's own window is gone — the next Go response overwrites it back, so whichever plan answered last wins and the entry is mislabelled either way. Zen's window cannot be read back either: every cooldown-scope consumer looks it up as `opencode-zen`, an id the file never held — `activeProviderCooldown` and `nextQuotaCooldownExpiry` key by `cooldownScope` (`provider-cooldown.mjs:53,75`).

To be precise about what this does *not* claim: the usage card is not affected today. `headerQuota` uses the raw id (`provider-account-usage.mjs:655`), but `providerAccountUsageSnapshot` filters variants out (`:1025`, `.filter((provider) => !provider.variantOf)`), so `opencode-zen` never reaches that path — one account entry per credential, as intended. Confirmed by executing it: with `providerIds: ["opencode-go", "opencode-zen"]` the returned snapshot has no `opencode-zen` key. The overwrite above is the effect that is live today; the unreadable-Zen half is the cooldown readers.

## What changed

`recordUpstreamLimits` keys the snapshot by `cooldownScope` — the same identity `recordProviderCooldown` two lines below already uses, so the two stores cannot drift apart again. The comment now records why the scope and the canonical id are not interchangeable here.

`opencode-zen` is the only id affected. Every other provider and variant — `commandcode-messages`, `opencode-go-messages`, `opencode-go-responses`, `opencode-free-responses` — has `cooldownScope === canonicalProviderId` and keeps the exact key it has today:

```
id                       variantOf      canonical      cooldownScope
commandcode-messages     commandcode    commandcode    commandcode
opencode-go-messages     opencode-go    opencode-go    opencode-go
opencode-go-responses    opencode-go    opencode-go    opencode-go
opencode-zen             opencode-go    opencode-go    opencode-zen   <-- DIVERGES
opencode-free-responses  opencode-free  opencode-free  opencode-free
```

A `rate-limits.json` already carrying a Zen-written entry under `opencode-go` needs no migration: it is last-write-wins telemetry with an `observedAt`, replaced by the next Go response that carries headers.

## Verification

- New `test/rate-limit-scope.test.mjs` spawns the real `src/api-forwarder.mjs` against a mock Zen upstream (a curated `opencode-zen` user model via `MODEL_ROUTER_USER_MODELS`, `OPENCODE_ZEN_BASE_URL` pointed at the mock), with `rate-limits.json` pre-seeded with the Go plan's window. It asserts Zen's headers land under `opencode-zen` and that the Go entry is untouched. It fails on unpatched `main` (`expected: 7`, the Zen figure never filed) and passes with the change.
- `node --test test/rate-limit-quota.test.mjs test/provider-cooldown.test.mjs test/provider-account-usage.test.mjs test/rate-limit-headers.test.mjs test/model-failover.test.mjs` — 102/102 pass.
- `node --test test/commandcode-forwarder.test.mjs` — 5/5 pass; its existing `limits.commandcode.requests.remaining` assertion pins the unchanged canonical-parent behaviour for a variant that shares its plan.
- `npm run check` passes.

Not touched: the first finding in #575 (the unreachable `subagent-availability-sync` / `provider-cooldown` circuit-breaker half). Wiring it or deleting it is your call, and this change is independent of it either way.
