### PR TITLE
fix: locate the checkout through symlinks in every bin/ command

### DIFF
--- a/bin/agents
+++ b/bin/agents
@@ -1,4 +1,17 @@
 #!/bin/sh
 set -eu
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/agent-bridges.mjs" "$@"

--- a/bin/api-key
+++ b/bin/api-key
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec "$repo_dir/bin/provider-key" kimi-api "$@"

--- a/bin/caller-key
+++ b/bin/caller-key
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/caller-key.mjs" "$@"

--- a/bin/chatgpt-session
+++ b/bin/chatgpt-session
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/chatgpt-session.mjs" "$@"

--- a/bin/codex-router
+++ b/bin/codex-router
@@ -7,10 +7,15 @@ set -eu
 # install` exposes this dispatcher and `codex-router setup` reaches the same
 # script `./bin/setup` does.
 #
-# Every sibling resolves its own root with `dirname $0`, which is only correct
-# when the script is invoked at its real path. The name a package manager puts
-# on PATH is a symlink into a versioned prefix, so this one walks the symlink
-# chain first and hands the resolved root to the sibling by calling it there.
+# Every sibling walks the same symlink chain before locating its root, and the
+# dispatcher must as well: a checkout user may link it onto PATH by hand, and
+# `bin_dir` is where the sibling it execs actually lives. The root is resolved
+# physically for the same reason as in the siblings, and a packaged install is
+# the case that needs it most: the formula's wrapper execs this script at
+# `<prefix>/opt/<formula>/libexec/bin/codex-router`, where the file is not a
+# link but `opt/<formula>` is one into the versioned keg, so the walk is a
+# no-op and only the physical root matches the path node realpaths a module to
+# before treating it as the main module.
 self=$0
 while [ -L "$self" ]; do
   link=$(readlink "$self")
@@ -19,8 +24,8 @@ while [ -L "$self" ]; do
     *) self=$(dirname -- "$self")/$link ;;
   esac
 done
-bin_dir=$(CDPATH= cd -- "$(dirname -- "$self")" && pwd)
-repo_dir=$(CDPATH= cd -- "$bin_dir/.." && pwd)
+bin_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")" && pwd -P)
+repo_dir=$(CDPATH= cd -P -- "$bin_dir/.." && pwd -P)
 
 usage() {
   cat <<'EOF'

--- a/bin/control
+++ b/bin/control
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/control.mjs" "$@"

--- a/bin/curate-models
+++ b/bin/curate-models
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/curate-models.mjs" "$@"

--- a/bin/devin-probe
+++ b/bin/devin-probe
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/devin-cli-probe.mjs" "$@"

--- a/bin/disable
+++ b/bin/disable
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 cd "$repo_dir"
 
 # The service, gateway, ports, and credentials are one plane shared by every

--- a/bin/discover-models
+++ b/bin/discover-models
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/model-discovery.mjs" "$@"

--- a/bin/doctor
+++ b/bin/doctor
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 case "${MODEL_ROUTER_TARGET:-codex}" in
   codex|dsh|gemini|cursor|claude|openclaw) exec node "$repo_dir/src/doctor.mjs" "$@" ;;
   *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, claude, or openclaw." >&2; exit 2 ;;

--- a/bin/enable
+++ b/bin/enable
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 cd "$repo_dir"
 target=${MODEL_ROUTER_TARGET:-codex}
 case "$target" in

--- a/bin/install
+++ b/bin/install
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH='' cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 prepare_only=false
 migrate_known=false
 adopt_native_catalog=false
@@ -492,8 +505,12 @@ else
   node src/target-integration.mjs restart-notice 2>/dev/null \
     || echo "Fully quit and reopen Codex, then start a new task."
 fi
-echo "Kimi API key: $repo_dir/bin/provider-key kimi-api set"
-echo "DeepSeek API key: $repo_dir/bin/provider-key deepseek set"
-echo "xAI API key: $repo_dir/bin/provider-key grok-api set"
-echo "Anthropic API key: $repo_dir/bin/provider-key anthropic-api set"
-echo "Chutes API key: $repo_dir/bin/provider-key chutes set"
+# A packaged install reaches this script through its stable `opt` path, which
+# `repo_dir` has just resolved to the versioned keg the next upgrade removes.
+# Hints are for the reader to run later, so name the path that survives.
+hint_dir=${CODEX_ROUTER_SOURCE_ROOT:-$repo_dir}
+echo "Kimi API key: $hint_dir/bin/provider-key kimi-api set"
+echo "DeepSeek API key: $hint_dir/bin/provider-key deepseek set"
+echo "xAI API key: $hint_dir/bin/provider-key grok-api set"
+echo "Anthropic API key: $hint_dir/bin/provider-key anthropic-api set"
+echo "Chutes API key: $hint_dir/bin/provider-key chutes set"

--- a/bin/key-pool
+++ b/bin/key-pool
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec "$repo_dir/bin/control" key-pool "$@"

--- a/bin/local-mlx
+++ b/bin/local-mlx
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/local-mlx.mjs" "$@"

--- a/bin/lock-python
+++ b/bin/lock-python
@@ -8,7 +8,20 @@
 # fails the suite while they disagree.
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 cd "$repo_dir"
 
 if ! command -v uv >/dev/null 2>&1; then

--- a/bin/media
+++ b/bin/media
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/minimax-media.mjs" "$@"

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 command=${1:-detect}
 case "$command" in
   detect) exec node "$repo_dir/src/legacy-migration.mjs" detect ;;

--- a/bin/model-router
+++ b/bin/model-router
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 
 usage() {
   cat <<'EOF'

--- a/bin/model-router-tray
+++ b/bin/model-router-tray
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH='' cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 if [ "${CODEX_ROUTER_PACKAGE_MANAGER:-}" = homebrew ]; then
   printf '%s\n' \
     'codex-router: the desktop companion is not packaged by Homebrew.' \

--- a/bin/multi-agent
+++ b/bin/multi-agent
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 cd "$repo_dir"
 # Codex-only on purpose. This toggle drives `multi_agent_version` and the
 # Codex agents directory -- native spawn overrides whose payloads are Codex's

--- a/bin/panel
+++ b/bin/panel
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 case "${MODEL_ROUTER_TARGET:-codex}" in
   codex) exec node "$repo_dir/src/panel.mjs" "$@" ;;
   *) echo "The companion panel is available only for the Codex target." >&2; exit 2 ;;

--- a/bin/provider-key
+++ b/bin/provider-key
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/provider-key.mjs" "$@"

--- a/bin/providers
+++ b/bin/providers
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/providers.mjs" "$@"

--- a/bin/refresh-catalog
+++ b/bin/refresh-catalog
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/refresh-catalog.mjs" "$@"

--- a/bin/rollback
+++ b/bin/rollback
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/update.mjs" rollback "$@"

--- a/bin/search-sidecar
+++ b/bin/search-sidecar
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 MODEL_ROUTER_TARGET=codex
 export MODEL_ROUTER_TARGET
 exec node "$repo_dir/src/search-sidecar-control.mjs" "$@"

--- a/bin/setup
+++ b/bin/setup
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 case "${MODEL_ROUTER_TARGET:-codex}" in
   codex|dsh|gemini|cursor|claude|openclaw) exec node "$repo_dir/src/setup.mjs" "$@" ;;
   *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, claude, or openclaw." >&2; exit 2 ;;

--- a/bin/shim
+++ b/bin/shim
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/shim-cli.mjs" "$@"

--- a/bin/skills
+++ b/bin/skills
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 case "${MODEL_ROUTER_TARGET:-codex}" in
   codex) exec node "$repo_dir/src/skills-install.mjs" "$@" ;;
   *) echo "Skills are a Codex client integration." >&2; exit 2 ;;

--- a/bin/smoke-test
+++ b/bin/smoke-test
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 # The smoke test spends provider quota against the shared router plane, so it
 # proves the same routes whichever client asked for it.
 case "${MODEL_ROUTER_TARGET:-codex}" in

--- a/bin/start
+++ b/bin/start
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 
 # `stop` unloads the background service, so `start` has to be able to put it
 # back. It used to exec the supervisor in the foreground instead, which made the

--- a/bin/status
+++ b/bin/status
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 cd "$repo_dir"
 case "${MODEL_ROUTER_TARGET:-codex}" in
   codex) node src/config-manager.mjs status ;;

--- a/bin/stop
+++ b/bin/stop
@@ -1,6 +1,19 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 cd "$repo_dir"
 node src/service.mjs stop

--- a/bin/subagent-preset
+++ b/bin/subagent-preset
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 cd "$repo_dir"
 case "${MODEL_ROUTER_TARGET:-codex}" in
   dsh) ;;

--- a/bin/support-bundle
+++ b/bin/support-bundle
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/support-bundle.mjs" "$@"

--- a/bin/test-model
+++ b/bin/test-model
@@ -1,5 +1,18 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 exec node "$repo_dir/src/compatibility-test.mjs" "$@"

--- a/bin/uninstall
+++ b/bin/uninstall
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 cd "$repo_dir"
 # The service, gateway, ports, and credentials are one plane shared by every
 # client integration -- the same reason `bin/disable` stopped tearing it down

--- a/bin/update
+++ b/bin/update
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -eu
 
-repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+# The name on PATH may be a symlink to this script, so walk the chain before
+# locating the repository root, and resolve that root physically: `dirname $0`
+# alone points beside the link, and a logical `..` climbs out of a linked
+# directory to a path node does not recognise as a module's own when it guards
+# main, so the command would quietly do nothing.
+self=$0
+while [ -L "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname -- "$self")/$link ;;
+  esac
+done
+repo_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")/.." && pwd -P)
 # Forward the subcommand so `update check` stays a read-only comparison instead
 # of silently performing a full update.
 if [ "$#" -eq 0 ]; then

--- a/test/bin-symlink-resolution.test.mjs
+++ b/test/bin-symlink-resolution.test.mjs
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const binDir = path.join(root, "bin");
+const posixOnly = process.platform === "win32" ? "the bin/ commands are not the Windows entry points" : false;
+
+// Every command in bin/ locates the checkout from its own path, and two things
+// can go wrong with that. A checkout user puts a command on PATH by hand --
+// `ln -s .../bin/doctor ~/.local/bin/doctor`, or a link to that link -- and
+// `dirname $0` alone resolves beside the link, so the command fails on a missing
+// src/ before it can say anything useful. Separately, most modules in src/ only
+// run as a command when `path.resolve(process.argv[1])` equals their own path,
+// and node realpaths a main module while leaving argv[1] as written, so a root
+// that still contains a linked directory makes those commands exit 0 having done
+// nothing. The second shape is what a packaged install has: the Homebrew wrapper
+// execs the dispatcher at `<prefix>/opt/<formula>/libexec/bin/codex-router`,
+// where the file is not a link but `opt/<formula>` is one into the versioned keg.
+const rootLocators = readdirSync(binDir).filter((entry) => {
+  const source = readFileSync(path.join(binDir, entry), "utf8");
+  return source.startsWith("#!/bin/sh\n") && /^repo_dir=/m.test(source);
+});
+
+function tempDir(prefix) {
+  return mkdtempSync(path.join(realpathSync(os.tmpdir()), prefix));
+}
+
+test("bin/ has shell commands that locate the repository root", () => {
+  assert.ok(rootLocators.length >= 30, `only ${rootLocators.length} bin/ commands compute repo_dir`);
+});
+
+test("every bin/ command walks the symlink chain and resolves its root physically", () => {
+  for (const entry of rootLocators) {
+    const source = readFileSync(path.join(binDir, entry), "utf8");
+    const where = `bin/${entry}`;
+    assert.match(source, /^self=\$0$/m, `${where} does not start from $0`);
+    assert.match(source, /^while \[ -L "\$self" \]; do$/m, `${where} does not walk the symlink chain`);
+    assert.match(source, /^    \/\*\) self=\$link ;;$/m, `${where} does not take an absolute link target as is`);
+    assert.match(
+      source,
+      /^    \*\) self=\$\(dirname -- "\$self"\)\/\$link ;;$/m,
+      `${where} does not rebase a relative link target on the link's directory`,
+    );
+    assert.match(
+      source,
+      /^repo_dir=\$\(CDPATH=(''|) cd -P -- "(\$\(dirname -- "\$self"\)|\$bin_dir)\/\.\." && pwd -P\)$/m,
+      `${where} does not derive a physical repo_dir from the resolved path`,
+    );
+    assert.doesNotMatch(source, /dirname -- "\$0"/, `${where} still derives a path from the unresolved $0`);
+  }
+});
+
+function isolatedEnv(dir) {
+  return {
+    ...process.env,
+    HOME: dir,
+    CODEX_HOME: path.join(dir, ".codex"),
+    MODEL_ROUTER_STATE_DIR: path.join(dir, "state"),
+    MODEL_ROUTER_TARGET: "codex",
+  };
+}
+
+// Commands whose usage comes from the module the shell script execs, so a root
+// resolved beside the link surfaces as node failing to find that module. skills
+// and agents reach modules that guard main on argv[1], so they also surface a
+// root that merely keeps a linked directory, which is a silent exit 0; doctor
+// prints its usage unguarded and covers only the missing-module shape. Each
+// prints usage without reading or writing configuration.
+const probes = [
+  { command: "skills", args: [], status: 2, usage: /Usage: skills-install/ },
+  { command: "agents", args: ["--help"], status: 2, usage: /Usage: agent-bridges/ },
+  { command: "doctor", args: ["--help"], status: 0, usage: /Usage: doctor/ },
+];
+
+function assertBehavesLikeDirect(probe, entry, env) {
+  const direct = spawnSync(path.join(binDir, probe.command), probe.args, { encoding: "utf8", env });
+  const result = spawnSync(entry, probe.args, { encoding: "utf8", env });
+  const output = `${result.stdout}${result.stderr}`;
+  assert.equal(result.status, probe.status, `${entry}: ${output}`);
+  assert.match(output, probe.usage, entry);
+  assert.doesNotMatch(output, /Cannot find module/, entry);
+  // Through the link the command behaves exactly as it does at its real path.
+  assert.equal(result.status, direct.status, entry);
+  assert.equal(output, `${direct.stdout}${direct.stderr}`, entry);
+}
+
+for (const probe of probes) {
+  test(`bin/${probe.command} resolves its root through a symlink`, { skip: posixOnly }, () => {
+    const dir = tempDir("codex-router-bin-");
+    try {
+      const target = path.join(binDir, probe.command);
+      const absolute = path.join(dir, probe.command);
+      symlinkSync(target, absolute);
+      // A relative target takes the branch that rebases it on the link's own
+      // directory, which is how package managers and dotfile tools write links.
+      const relative = path.join(dir, `${probe.command}-relative`);
+      symlinkSync(path.relative(dir, target), relative);
+      // A link to a link: `ln -s ~/.local/bin/x ~/bin/x` on top of the first one.
+      const chained = path.join(dir, `${probe.command}-chained`);
+      symlinkSync(absolute, chained);
+      for (const entry of [absolute, relative, chained]) {
+        assertBehavesLikeDirect(probe, entry, isolatedEnv(dir));
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test(`bin/${probe.command} resolves its root through a linked directory`, { skip: posixOnly }, () => {
+    // Here $0 is not itself a link, so only the physical resolution of the root
+    // stands between the command and a silent no-op.
+    const dir = tempDir("codex-router-dir-");
+    try {
+      // The whole bin/ directory linked onto PATH: `ln -s <checkout>/bin ~/cr-bin`.
+      const linkedBin = path.join(dir, "cr-bin");
+      symlinkSync(binDir, linkedBin);
+      assertBehavesLikeDirect(probe, path.join(linkedBin, probe.command), isolatedEnv(dir));
+      // The checkout itself reached through a link, as under macOS /tmp or a
+      // linked ~/code, with the command linked from inside that view of it.
+      const aliased = path.join(dir, "aliased");
+      symlinkSync(root, aliased);
+      mkdirSync(path.join(dir, "bin"));
+      const viaAlias = path.join(dir, "bin", probe.command);
+      symlinkSync(path.join(aliased, "bin", probe.command), viaAlias);
+      assertBehavesLikeDirect(probe, viaAlias, isolatedEnv(dir));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+}
+
+test("a packaged keg layout reaches its commands through the dispatcher", { skip: posixOnly }, () => {
+  // The shape packaging/homebrew/codex-router.rb produces: a generated wrapper in
+  // the formula's bin/ exports CODEX_ROUTER_SOURCE_ROOT and execs the dispatcher
+  // under `opt/<formula>`, a symlink to the versioned keg. Nothing on that path is
+  // a link the walk can see, so the physical root is the whole of what makes the
+  // commands behind it run. rmSync unlinks a directory symlink rather than
+  // descending through it, so the checkout the keg points at is not touched.
+  const dir = tempDir("codex-router-keg-");
+  try {
+    const keg = path.join(dir, "Cellar", "codex-router", "1.0.0");
+    mkdirSync(keg, { recursive: true });
+    symlinkSync(root, path.join(keg, "libexec"));
+    mkdirSync(path.join(dir, "opt"));
+    symlinkSync(path.join("..", "Cellar", "codex-router", "1.0.0"), path.join(dir, "opt", "codex-router"));
+    const optLibexec = path.join(dir, "opt", "codex-router", "libexec");
+    const wrapper = path.join(dir, "bin", "codex-router");
+    mkdirSync(path.join(dir, "bin"));
+    writeFileSync(
+      wrapper,
+      `#!/bin/sh\nCODEX_ROUTER_PACKAGE_MANAGER=homebrew\nCODEX_ROUTER_SOURCE_ROOT="${optLibexec}"\n` +
+        `export CODEX_ROUTER_PACKAGE_MANAGER CODEX_ROUTER_SOURCE_ROOT\nexec "${optLibexec}/bin/codex-router" "$@"\n`,
+    );
+    chmodSync(wrapper, 0o755);
+    for (const probe of probes) {
+      const env = isolatedEnv(dir);
+      const result = spawnSync(wrapper, [probe.command, ...probe.args], { encoding: "utf8", env });
+      const output = `${result.stdout}${result.stderr}`;
+      assert.equal(result.status, probe.status, `${probe.command} through the keg: ${output}`);
+      assert.match(output, probe.usage, `${probe.command} through the keg`);
+      assert.doesNotMatch(output, /Cannot find module/, probe.command);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the walk and the physical cd are what make a linked command find its root", { skip: posixOnly }, () => {
+  // The same script minus the walk reports the link's grandparent, which is the
+  // failure every command had. The resolver is taken verbatim from a shipped
+  // command so this control keeps tracking what actually ships.
+  const dir = tempDir("codex-router-walk-");
+  try {
+    const home = path.join(dir, "home");
+    const fakeRoot = path.join(home, "src", "root");
+    mkdirSync(path.join(fakeRoot, "bin"), { recursive: true });
+    const resolver = readFileSync(path.join(binDir, "skills"), "utf8").match(/^self=\$0\n[\s\S]*?^repo_dir=.*$/m);
+    assert.ok(resolver, "bin/skills carries the resolver");
+    const walked = path.join(fakeRoot, "bin", "walked");
+    const bare = path.join(fakeRoot, "bin", "bare");
+    writeFileSync(walked, `#!/bin/sh\nset -eu\n${resolver[0]}\nprintf '%s' "$repo_dir"\n`);
+    writeFileSync(
+      bare,
+      '#!/bin/sh\nset -eu\nrepo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)\nprintf \'%s\' "$repo_dir"\n',
+    );
+    chmodSync(walked, 0o755);
+    chmodSync(bare, 0o755);
+    const links = path.join(home, "links", "bin");
+    mkdirSync(links, { recursive: true });
+    symlinkSync(walked, path.join(links, "walked"));
+    symlinkSync(path.relative(links, walked), path.join(links, "walked-relative"));
+    symlinkSync(bare, path.join(links, "bare"));
+    // A dotfiles layout: ~/bin is itself a link, and the command inside it is a
+    // relative link that climbs out with `..`. The kernel follows ~/bin to its
+    // target before applying `..`; a logical cd strips `..` textually instead and
+    // lands one level up, where nothing exists, so the command aborts.
+    mkdirSync(path.join(home, "dotfiles", "bin"), { recursive: true });
+    symlinkSync(path.join("dotfiles", "bin"), path.join(home, "bin"));
+    symlinkSync(path.join("..", "..", "src", "root", "bin", "walked"), path.join(home, "dotfiles", "bin", "walked"));
+    const run = (entry) => spawnSync(entry, [], { encoding: "utf8" });
+    assert.equal(run(path.join(links, "walked")).stdout, fakeRoot);
+    assert.equal(run(path.join(links, "walked-relative")).stdout, fakeRoot);
+    assert.equal(run(path.join(links, "bare")).stdout, path.join(home, "links"));
+    const stowed = run(path.join(home, "bin", "walked"));
+    assert.equal(stowed.status, 0, stowed.stderr);
+    assert.equal(stowed.stdout, fakeRoot);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/codex-router-cli.test.mjs
+++ b/test/codex-router-cli.test.mjs
@@ -25,11 +25,11 @@ function run(args, options = {}) {
   return spawnSync(dispatcher, args, { encoding: "utf8", ...options });
 }
 
-// The dispatcher exists so a packaged install can expose one name on PATH, and
-// the name a package manager exposes is a symlink into a versioned prefix. Every
-// sibling in bin/ resolves its root with `dirname $0`, so a dispatcher that does
-// not walk the symlink chain hands them a root one directory above the package
-// prefix and every command fails on a missing src/.
+// The dispatcher exists so a packaged install can expose one name on PATH. A
+// checkout user links it onto PATH by hand, and a dispatcher that does not walk
+// that symlink chain looks for its siblings beside the link and reports every
+// command as unknown. test/bin-symlink-resolution.test.mjs covers the siblings,
+// and the linked-directory case the Homebrew layout actually produces.
 function linkedCopy(target) {
   const dir = mkdtempSync(path.join(realpathSync(os.tmpdir()), "codex-router-cli-"));
   const link = path.join(dir, target);
@@ -58,8 +58,9 @@ test("the dispatcher resolves its root through a symlink", { skip: posixOnly }, 
 });
 
 test("the dispatcher resolves a chain of symlinks", { skip: posixOnly }, () => {
-  // Homebrew stacks two: `bin/codex-router` points at `opt/<name>/...`, which is
-  // itself a symlink into the versioned Cellar directory.
+  // A user stacks two by hand: `~/bin/x -> ~/.local/bin/x -> checkout/bin/...`.
+  // Homebrew itself ships a wrapper script here, not a link; its only link is the
+  // `opt/<formula>` directory, which `[ -L ]` on the file never sees.
   const { dir, link } = linkedCopy("codex-router");
   try {
     const chained = path.join(dir, "chained");


### PR DESCRIPTION
## What

Every command in `bin/` located the checkout with

    repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)

`dirname $0` is only right when the script runs at its real path, and the logical `cd` is only right when no directory on the way is a symlink. `bin/codex-router` already walked the symlink chain, and its comment recorded that the siblings did not; this inlines the same walk into all 38 of them and resolves the root physically (`cd -P … && pwd -P`, the idiom `bin/model-router-tray:683` already uses).

Two distinct failures follow from the old form.

**A command linked onto PATH cannot find the checkout.** `ln -s ~/src/codex-router/bin/doctor ~/.local/bin/doctor` gives

    Error: Cannot find module '/Users/me/.local/src/doctor.mjs'

Relative links that climb out of a linked directory (GNU Stow's folded `~/bin`) are worse: the walk yields a path the kernel accepts, the logical `cd` strips `..` textually, and the command aborts under `set -e` on dash and macOS `/bin/sh`. Only bash invoked as `bash` retries physically and hides it.

**A root containing a linked directory makes commands silently do nothing.** 52 modules in `src/` guard main with `path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)`. Node realpaths a main module but leaves `argv[1]` as written, so `node "$repo_dir/src/x.mjs"` with a logical `$repo_dir` fails that comparison: the module imports and the process exits 0, having done nothing.

## This also fixes Homebrew installs

The packaged install is the second case, and I did not expect this going in. The formula's wrapper execs `<prefix>/opt/<formula>/libexec/bin/codex-router`. That file is not a link — so the walk is a no-op there — but `opt/<formula>` is a link into the versioned keg, so `repo_dir` stayed on the `opt` path. Every command behind a guarded module (`agents`, `skills`, `caller-key`, `providers`, `update`, `refresh-catalog`, `support-bundle`, …) exited 0 without running. The commands that appeared to work — `--version`, `help`, `setup`, `doctor`, `control`, `panel`, `provider-key` — are the ones that never cross a guard, and the formula's `test do` block only runs those, so CI never saw it.

Reproduced in a keg-shaped fixture built from this repo's own files: on `99d526d`, `codex-router skills` exits 0 with no output; with this patch it prints usage and exits 2. `test/bin-symlink-resolution.test.mjs` now builds that layout by name so it stays covered.

I can only simulate the keg layout here rather than install the formula, so please sanity-check this against a real `brew install` before trusting the claim.

## Behaviour changes worth flagging

- `bin/install`'s five closing API-key hints printed `$repo_dir`, which is now the versioned keg path for a packaged reader — stale after the next `brew upgrade`. They now print `${CODEX_ROUTER_SOURCE_ROOT:-$repo_dir}`, so a packaged install names the stable `opt` path and a checkout is unchanged.
- `bin/model-router-tray` runs `$repo_dir/scripts/build-macos-tray-app.sh`, which seals its root into the tray bundle (`Contents/Resources/router-root` and Info.plist `ModelRouterSourceRoot`). For a checkout reached through a linked directory that sealed root is now physical rather than logical. Homebrew is not affected — the tray exits early when `CODEX_ROUTER_PACKAGE_MANAGER=homebrew`. Tell me if you would rather it kept the logical path.
- Otherwise `$repo_dir` is transient: it names the module to run, is `cd`'d into, and locates sibling commands. Node's own `SOURCE_ROOT` still comes from `CODEX_ROUTER_SOURCE_ROOT` when the wrapper exports it, so nothing persisted into launchd/systemd units changes.

## Why inline it 38 times

A sourced helper cannot be found before the path is resolved — `. helper` searches PATH, which is exactly what holds only the link. `readlink -f`/`realpath` need macOS ≥ 12.3; the dispatcher's existing walk depends on neither, and the one `readlink -f` in `bin/` (`model-router-tray:805`) sits in a Linux-only `/proc` branch behind a fallback. A node one-liner would put node on the critical path of `bin/install`, the script that decides where node comes from. So the siblings follow the dispatcher, and the static test pins the load-bearing lines in every copy so they cannot drift.

## Tests

`test/bin-symlink-resolution.test.mjs`:
- static: every `#!/bin/sh` command in `bin/` starts from `$0`, walks the chain, carries both `case` branches, derives a physical `repo_dir`, and never derives a path from bare `$0`
- `bin/skills`, `bin/agents --help`, `bin/doctor --help` through an absolute link, a relative link, a link to a link, a linked `bin/` directory, a linked checkout, and a keg-shaped wrapper — each must behave byte-for-byte as at the real path, under an isolated `HOME`/`CODEX_HOME`/`MODEL_ROUTER_STATE_DIR`. `skills` and `agents` reach guarded modules and so cover the silent-exit-0 shape; `doctor` prints usage unguarded and covers only the missing-module shape
- a control taking the resolver verbatim from `bin/skills`, showing the bare `dirname $0` form landing one level above the link's directory, and resolving the Stow layout

`sh -n` and `dash -n` pass on every script. Full suite locally on macOS: 3977 tests, 3947 pass, 28 skipped, 2 failures (`desktop-panel` needs playwright, a `search-sidecar` cancellation timing test) that reproduce unpatched on `99d526d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
