### PR TITLE
fix(free): free Muse Spark 1.3 keeps web-search history

### DIFF
--- a/config/opencode-free/responses/muse-spark-1.3-contributor-free.json
+++ b/config/opencode-free/responses/muse-spark-1.3-contributor-free.json
@@ -40,10 +40,11 @@
         "image"
       ],
       "isFree": true,
+      "supportsSearchHistory": true,
       "supportsApplyPatchTool": false,
       "requestProfile": "auto-tool-choice",
       "toolSchemaRecursion": "flatten",
-      "compHash": "opencode-free-responses-muse-spark-1-3-contributor-free-v1"
+      "compHash": "opencode-free-responses-muse-spark-1-3-contributor-free-v2"
     }
   ]
 }

--- a/test/search-capability.test.mjs
+++ b/test/search-capability.test.mjs
@@ -67,6 +67,7 @@ test("checked-in opencode Muse Responses routes replay verified search history w
   for (const slug of [
     "opencode-go-responses/muse-spark-1.2-contributor",
     "opencode-go-responses/muse-spark-1.3-contributor",
+    "opencode-free-responses/muse-spark-1.3-contributor-free",
   ]) {
     const model = MODEL_BY_SLUG.get(slug);
     assert.ok(model, slug);


### PR DESCRIPTION
Live replay probe on `opencode-free-responses/muse-spark-1.3-contributor-free`: a resumed thread carrying 5 completed `web_search_call` items returned 4x200 instead of `400 model_search_not_supported`.

Probe data (2026-09-12): before — same follow-up turn failed in 216ms with 0 tokens (`router.log 18:30:17 status=400 total_ms=83`); after — `codex exec resume` of the same session exited 0 with a normal answer (upstream `18:54-18:55`: 4x200, 19.6s/11.4s/5.6s/9.2s, out 873+714+260+336). `test/search-capability.test.mjs` 7/7 pass; fresh `codex exec` smoke `router-ok` exit 0.

Mirrors #639 (go twins), which carry the same flag. Change: `supportsSearchHistory: true`, compHash v1->v2, plus test pin.