### PR TITLE
chore: merge CHANGELOG.md bullets instead of conflicting on them

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,15 @@ bin/* text eol=lf
 # and are conventionally CRLF, but nothing here depends on their endings, so
 # they are normalized in the repository and left to the platform on checkout.
 *.ps1 text
+
+# Every change here appends a bullet to the top of CHANGELOG.md's `## Unreleased`
+# section, so two branches that share no source file still collide on it. That
+# was the single largest source of conflicts in the open queue: of ten
+# conflicting pull requests, seven conflicted on this file and nothing else.
+#
+# `union` is git's built-in driver for exactly this shape -- an append-only list
+# whose entries are independent. It keeps both sides' bullets instead of asking
+# a human to re-type one. The cost is that when both sides edit the *same*
+# bullet it keeps both copies, which is a visible one-line delete rather than a
+# conflict to resolve; pick the surviving wording when that happens.
+CHANGELOG.md merge=union


### PR DESCRIPTION
## Why

Every change appends a bullet to the top of `CHANGELOG.md`'s `## Unreleased` section, so two branches that share no source file still collide there.

That is not a minor annoyance — it is currently the single largest source of conflicts in the open queue. Of the ten conflicting open pull requests, **seven conflict on `CHANGELOG.md` and nothing else**:

| PR | conflicting files before | after |
|---|---|---|
| #708 | CHANGELOG.md | none |
| #710 | CHANGELOG.md | none |
| #714 | CHANGELOG.md | none |
| #715 | CHANGELOG.md | none |
| #716 | CHANGELOG.md | none |
| #728 | CHANGELOG.md | none |
| #729 | CHANGELOG.md | none |

## What

Four lines plus a comment in `.gitattributes`:

```
CHANGELOG.md merge=union
```

`union` is git's built-in driver for exactly this shape — an append-only list whose entries are independent of each other. It keeps both sides' bullets rather than asking a human to re-type one.

## Verification

Each of the seven was re-merged against `main` with the attribute in place (`git merge-tree --write-tree`), and all seven go to zero conflicts. The three remaining conflicts are genuine source conflicts, untouched by this change:

- #720 — `test/tool-schema-root.test.mjs`
- #725 — `src/router.mjs`
- #605 — `src/chat-tool-surface.mjs`, `src/namespace-relay.mjs`, `src/router.mjs`, `test/provider-catalogs.test.mjs`

I also checked the merged output rather than just the conflict count: no conflict markers, and no bullet lost from either side.

## The tradeoff, stated plainly

When both sides edit the *same* bullet, `union` keeps both copies. In one of the test merges that produced a single duplicated bullet (210 where 209 were expected). That is a one-line delete with both wordings visible, rather than a conflict someone has to reconstruct from two halves — and it only ever applies to this one file.

If a cleaner shape is wanted later, the alternative is `changelog.d/` fragments assembled at release, which never conflict and never duplicate, at the cost of a release-time assembly step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)