### PR TITLE
fix(commandcode): normalize nullable Gemini tool schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Command Code's Gemini 3.8 Flash accepts nullable tool parameters.** Convert
+  a single concrete type plus `null` to an explicit union before forwarding,
+  preserving array constraints and nested schemas. This prevents the observed
+  `any_of` sibling-field rejection for Codex's image-generation tool, including
+  definitions restored from tool-search history. Other routes keep their schemas.
 - **Blank tool-call messages and direct DeepSeek reasoning are repaired behind
   large tool lists.** LiteLLM echoes the request's instructions and whole tool
   list in `response.created` and `response.in_progress`. The stream repairs

--- a/src/gemini-tool-schema.mjs
+++ b/src/gemini-tool-schema.mjs
@@ -1,0 +1,210 @@
+// Gemini rejected image_gen's nullable type arrays after upstream translation
+// introduced anyOf with sibling fields. Spell one concrete type plus null as
+// an explicit union instead; retain its type-specific constraints on the
+// non-null branch. The Google AI SDK recognizes this shape and flattens it to
+// a nullable concrete type, without the invalid anyOf siblings:
+// https://github.com/vercel/ai/blob/main/packages/google/src/convert-json-schema-to-openapi-schema.ts
+//
+// Only simple nullable nodes are rewritten. Composition and reference keywords
+// can constrain null or depend on their location; enum/const use a separate
+// upstream conversion path. Leave those shapes unchanged.
+const REWRITE_BLOCKERS = [
+  // Composition and conditional keywords apply regardless of the instance
+  // type, so moving them onto one branch could change what the schema accepts.
+  "anyOf",
+  "oneOf",
+  "allOf",
+  "not",
+  "if",
+  "then",
+  "else",
+  // Identity and container keywords are not constraints; moving them would
+  // change how references inside the schema resolve.
+  "$ref",
+  "$defs",
+  "definitions",
+  "$id",
+  "$anchor",
+  "$dynamicAnchor",
+  "$dynamicRef",
+  "$recursiveRef",
+  "$schema",
+  // Literals: see the note above.
+  "enum",
+  "const",
+];
+
+// JSON Schema positions. `$defs`, `properties` and friends are maps of
+// schemas, the union keywords are arrays of schemas, and the remaining
+// keywords each hold one schema. Literal data under `const`, `default`,
+// `examples` and `enum` is never entered: an object that merely looks like a
+// schema there is a value the tool accepts, not a schema.
+const SCHEMA_MAP_KEYWORDS = [
+  "$defs",
+  "definitions",
+  "properties",
+  "patternProperties",
+  "dependentSchemas",
+];
+const SCHEMA_LIST_KEYWORDS = ["allOf", "anyOf", "oneOf", "prefixItems"];
+const SCHEMA_CHILD_KEYWORDS = [
+  "additionalItems",
+  "additionalProperties",
+  "contains",
+  "contentSchema",
+  "else",
+  "if",
+  "items",
+  "not",
+  "propertyNames",
+  "then",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+];
+
+const MAX_DEPTH = 32;
+
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// The single non-null member of a nullable type array, or undefined when the
+// shape is anything else -- including `["null"]` alone, which the converter
+// already turns into a bare `type: "null"`, and a multi-type union, which it
+// still emits as `anyOf` with siblings and is not a shape this route has
+// demonstrated.
+function nullableTypeMember(type) {
+  if (!Array.isArray(type) || !type.includes("null")) return undefined;
+  const nonNull = type.filter((entry) => entry !== "null");
+  if (nonNull.length !== 1 || typeof nonNull[0] !== "string") return undefined;
+  return nonNull[0];
+}
+
+// Returns `schema` by identity when the shape is not the one to repair, so an
+// ordinary node costs one check and no copy.
+function rewriteNullableTypeArray(schema) {
+  const nonNullType = nullableTypeMember(schema.type);
+  if (nonNullType === undefined) return schema;
+  if (REWRITE_BLOCKERS.some((keyword) => Object.hasOwn(schema, keyword))) return schema;
+  const { type: _nullableTypeArray, ...branch } = schema;
+  return {
+    anyOf: [{ type: nonNullType, ...branch }, { type: "null" }],
+  };
+}
+
+function repairSchemaNode(schema, depth) {
+  if (!isPlainObject(schema) || depth > MAX_DEPTH) return schema;
+  let next = rewriteNullableTypeArray(schema);
+  // Copy-on-write: `next` is already this function's own object when the node
+  // was rewritten, and a copy of the caller's object otherwise.
+  const replace = (key, value) => {
+    if (next === schema) next = { ...schema };
+    next[key] = value;
+  };
+  const repairChild = (child) => repairSchemaNode(child, depth + 1);
+
+  for (const keyword of SCHEMA_MAP_KEYWORDS) {
+    const schemas = next[keyword];
+    if (!isPlainObject(schemas)) continue;
+    let changed = false;
+    const rewritten = Object.create(null);
+    for (const [name, child] of Object.entries(schemas)) {
+      const repaired = repairChild(child);
+      if (repaired !== child) changed = true;
+      rewritten[name] = repaired;
+    }
+    if (changed) replace(keyword, rewritten);
+  }
+
+  for (const keyword of [...SCHEMA_LIST_KEYWORDS, ...SCHEMA_CHILD_KEYWORDS]) {
+    const children = next[keyword];
+    if (Array.isArray(children)) {
+      // Drafts before 2020-12 allowed tuple schemas directly under `items`.
+      let changed = false;
+      const rewritten = children.map((child) => {
+        const repaired = repairChild(child);
+        if (repaired !== child) changed = true;
+        return repaired;
+      });
+      if (changed) replace(keyword, rewritten);
+      continue;
+    }
+    if (!isPlainObject(children)) continue;
+    const repaired = repairChild(children);
+    if (repaired !== children) replace(keyword, repaired);
+  }
+
+  // Draft-07 `dependencies` mixes property-name arrays with schema values.
+  const dependencies = next.dependencies;
+  if (isPlainObject(dependencies)) {
+    let changed = false;
+    const rewritten = Object.create(null);
+    for (const [name, child] of Object.entries(dependencies)) {
+      const repaired = isPlainObject(child) ? repairChild(child) : child;
+      if (repaired !== child) changed = true;
+      rewritten[name] = repaired;
+    }
+    if (changed) replace("dependencies", rewritten);
+  }
+
+  return next;
+}
+
+// One parameter schema, in the shape the provider will convert. Returns the
+// input by identity when it carries no nullable type array, so a clean toolset
+// is never copied and the caller's object is never mutated. Applying the
+// result again is a no-op: the rewritten node has `anyOf` and no `type` array.
+export function geminiToolSchema(schema) {
+  if (!isPlainObject(schema)) return schema;
+  return repairSchemaNode(schema, 0);
+}
+
+// The provider-facing `parameters` and the client's native `inputSchema` both
+// reach the wire on a flattened namespace child, so both are repaired. Native
+// namespace entries keep their shape and have their children repaired.
+export function repairGeminiToolSchema(tool) {
+  if (tool?.type === "namespace" && Array.isArray(tool.tools)) {
+    let changed = false;
+    const children = tool.tools.map((child) => {
+      const repaired = repairGeminiToolSchema(child);
+      if (repaired !== child) changed = true;
+      return repaired;
+    });
+    return changed ? { ...tool, tools: children } : tool;
+  }
+
+  let repairedTool = tool;
+  let changed = false;
+  if (tool?.function?.parameters !== undefined) {
+    const parameters = geminiToolSchema(tool.function.parameters);
+    if (parameters !== tool.function.parameters) {
+      repairedTool = {
+        ...repairedTool,
+        function: { ...repairedTool.function, parameters },
+      };
+      changed = true;
+    }
+  }
+  for (const field of ["parameters", "inputSchema"]) {
+    const schema = tool?.[field];
+    if (schema === undefined) continue;
+    const repaired = geminiToolSchema(schema);
+    if (repaired === schema) continue;
+    repairedTool = { ...repairedTool, [field]: repaired };
+    changed = true;
+  }
+  return changed ? repairedTool : tool;
+}
+
+// Array form for the router's tool boundary. Returns the original array when
+// nothing needed repair, so an ordinary request is not copied.
+export function repairGeminiToolSchemas(tools) {
+  if (!Array.isArray(tools)) return tools;
+  let changed = false;
+  const repaired = tools.map((tool) => {
+    const next = repairGeminiToolSchema(tool);
+    if (next !== tool) changed = true;
+    return next;
+  });
+  return changed ? repaired : tools;
+}

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -130,6 +130,7 @@ import {
   tokenUsageFromPayload,
 } from "./response-usage.mjs";
 import { fetchWithRetry } from "./upstream-retry.mjs";
+import { repairGeminiToolSchemas } from "./gemini-tool-schema.mjs";
 import { applyGrokApplyPatchGuidance } from "./grok-apply-patch-guidance.mjs";
 import {
   GROK_STRUCTURED_PATCH_CODEC,
@@ -1056,6 +1057,16 @@ function needsNonRecursiveToolSchemaCompatibility(route) {
     needsZenFreeToolCompatibility(route) ||
     (providerId === "opencode-go-responses" &&
       route.upstreamModel === "muse-spark-1.2-contributor")
+  );
+}
+
+// This route rejected image_gen's nullable array after upstream conversion
+// produced anyOf with sibling fields. Match the provider/model pair so aliases
+// of the same upstream receive the repair without changing other routes.
+function needsCommandCodeGeminiToolSchemaCompatibility(route) {
+  return (
+    providerForModel(route)?.id === "commandcode" &&
+    route.upstreamModel === "google/gemini-3.8-flash"
   );
 }
 
@@ -3414,6 +3425,10 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
       // repair pass, so enforce the same boundary on the expanded inventory.
       tools = repairToolSchemaRoots(tools, { nonRecursive: true });
     }
+  }
+  if (needsCommandCodeGeminiToolSchemaCompatibility(route)) {
+    // Normalize the complete inventory once, including stored search results.
+    tools = repairGeminiToolSchemas(tools);
   }
   // Stored call history and forced choices must use the same tool names as the
   // provider-facing list, or the model/request validator sees two identities.

--- a/test/gemini-tool-schema.test.mjs
+++ b/test/gemini-tool-schema.test.mjs
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  geminiToolSchema,
+  repairGeminiToolSchema,
+  repairGeminiToolSchemas,
+} from "../src/gemini-tool-schema.mjs";
+
+// The two fields Codex ships inside `image_gen__imagegen` that reach Gemini
+// through Command Code. The array field is the one the live rejection named:
+// "parameters.referenced_image_paths schema specified other fields alongside
+// any_of. When using any_of, it must be the only field set."
+function imageGenParameters() {
+  return {
+    type: "object",
+    properties: {
+      prompt: { type: "string", description: "What to draw." },
+      referenced_image_paths: {
+        type: ["array", "null"],
+        items: { type: "string" },
+        description: "Paths to images the edit should reference.",
+      },
+      num_last_images_to_include: { type: ["number", "null"] },
+    },
+    required: ["prompt"],
+  };
+}
+
+test("the image_gen nullable fields become explicit nullable unions", () => {
+  const repaired = geminiToolSchema(imageGenParameters());
+  const paths = repaired.properties.referenced_image_paths;
+  // The union node carries no sibling keyword at all -- that is exactly the
+  // shape Gemini's validator demands -- and the array constraints and
+  // description move onto the branch they describe.
+  assert.deepEqual(Object.keys(paths), ["anyOf"]);
+  assert.deepEqual(paths, {
+    anyOf: [
+      {
+        type: "array",
+        items: { type: "string" },
+        description: "Paths to images the edit should reference.",
+      },
+      { type: "null" },
+    ],
+  });
+  assert.deepEqual(repaired.properties.num_last_images_to_include, {
+    anyOf: [{ type: "number" }, { type: "null" }],
+  });
+  // Everything else about the tool is untouched.
+  assert.equal(repaired.type, "object");
+  assert.deepEqual(repaired.required, ["prompt"]);
+  assert.deepEqual(repaired.properties.prompt, imageGenParameters().properties.prompt);
+});
+
+// A local model of the upstream conversion the error came from, kept to the
+// paths this repair depends on: `@ai-sdk/google`'s
+// convert-json-schema-to-openapi-schema.ts turns a nullable type array into
+// `anyOf` plus `nullable` and then keeps the node's other keywords, while an
+// explicit one-non-null-branch `anyOf` plus `{type:"null"}` is flattened into
+// the converted branch with no surviving `anyOf`. It is a test oracle for the
+// failure mode, not a reimplementation of the provider; the route itself is
+// verified live against Command Code.
+function convertToGeminiSchema(jsonSchema) {
+  const result = {};
+  if (jsonSchema.description) result.description = jsonSchema.description;
+  if (jsonSchema.required) result.required = jsonSchema.required;
+  if (jsonSchema.type) {
+    if (Array.isArray(jsonSchema.type)) {
+      const nonNull = jsonSchema.type.filter((entry) => entry !== "null");
+      if (nonNull.length === 0) {
+        result.type = "null";
+      } else {
+        result.anyOf = nonNull.map((entry) => ({ type: entry }));
+        if (jsonSchema.type.includes("null")) result.nullable = true;
+      }
+    } else {
+      result.type = jsonSchema.type;
+    }
+  }
+  if (jsonSchema.properties) {
+    result.properties = {};
+    for (const [name, child] of Object.entries(jsonSchema.properties)) {
+      result.properties[name] = convertToGeminiSchema(child);
+    }
+  }
+  if (jsonSchema.items) result.items = convertToGeminiSchema(jsonSchema.items);
+  if (jsonSchema.anyOf) {
+    const nullable = jsonSchema.anyOf.some((branch) => branch?.type === "null");
+    const nonNull = jsonSchema.anyOf.filter((branch) => branch?.type !== "null");
+    if (nullable && nonNull.length === 1) {
+      result.nullable = true;
+      Object.assign(result, convertToGeminiSchema(nonNull[0]));
+    } else {
+      result.anyOf = jsonSchema.anyOf.map(convertToGeminiSchema);
+      if (nullable) result.nullable = true;
+    }
+  }
+  return result;
+}
+
+test("the repaired schema converts without any_of beside other fields", () => {
+  const original = imageGenParameters().properties.referenced_image_paths;
+  // The shipping shape is the failing one: the converter leaves `anyOf` and
+  // `items` on the same node, which is the reported rejection.
+  const broken = convertToGeminiSchema(original);
+  assert.deepEqual(broken.anyOf, [{ type: "array" }]);
+  assert.deepEqual(broken.items, { type: "string" });
+
+  const repaired = geminiToolSchema(imageGenParameters());
+  const converted = convertToGeminiSchema(repaired).properties.referenced_image_paths;
+  assert.equal(converted.anyOf, undefined);
+  assert.equal(converted.type, "array");
+  assert.equal(converted.nullable, true);
+  // The array's item constraint is still there.
+  assert.deepEqual(converted.items, { type: "string" });
+  assert.equal(converted.description, "Paths to images the edit should reference.");
+  assert.deepEqual(
+    convertToGeminiSchema(repaired).properties.num_last_images_to_include,
+    { type: "number", nullable: true },
+  );
+});
+
+test("the rewrite is idempotent and leaves compatible schemas by identity", () => {
+  const repaired = geminiToolSchema(imageGenParameters());
+  assert.equal(geminiToolSchema(repaired), repaired);
+  assert.deepEqual(geminiToolSchema(repaired), repaired);
+
+  const ordinary = {
+    type: "object",
+    properties: {
+      window: { type: "array", items: { type: "number" }, minItems: 1 },
+      label: { type: "string", maxLength: 8 },
+    },
+  };
+  assert.equal(geminiToolSchema(ordinary), ordinary);
+
+  // An explicit union already states its alternative, and the converter
+  // collapses it on its own -- rewriting it would only add risk.
+  const explicit = {
+    type: "object",
+    properties: {
+      value: { anyOf: [{ type: "string" }, { type: "null" }], description: "Either." },
+    },
+  };
+  assert.equal(geminiToolSchema(explicit), explicit);
+});
+
+test("shapes the rewrite deliberately does not claim are left alone", () => {
+  const cases = [
+    // A union of several non-null types is not the observed shape.
+    { type: ["string", "number", "null"] },
+    // A node whose null alternative carries a literal would make the converter
+    // throw if `enum` were moved into the non-null branch.
+    { type: ["string", "null"], enum: ["a", null] },
+    { type: ["string", "null"], const: "a" },
+    // Explicit composition and reference keywords stay where they are.
+    { type: ["array", "null"], allOf: [{ maxItems: 3 }] },
+    { type: ["array", "null"], $ref: "#/$defs/list" },
+    { type: ["null"] },
+  ];
+  for (const schema of cases) {
+    assert.equal(geminiToolSchema(schema), schema, JSON.stringify(schema));
+  }
+});
+
+test("literal data that looks like a schema is never rewritten", () => {
+  const literal = { type: ["array", "null"], items: { type: "string" } };
+  const schema = {
+    type: "object",
+    properties: { value: { type: ["string", "null"] } },
+    default: literal,
+    examples: [literal],
+  };
+  const repaired = geminiToolSchema(schema);
+  assert.equal(repaired.default, literal);
+  assert.deepEqual(repaired.examples, [literal]);
+  assert.deepEqual(repaired.default, { type: ["array", "null"], items: { type: "string" } });
+});
+
+test("nullable array constraints and special property names survive serialization", () => {
+  const schema = JSON.parse('{"type":"object","properties":{"__proto__":{"type":["array","null"],"items":{"type":"string"},"minItems":1,"maxItems":2}},"required":["__proto__"],"additionalProperties":false}');
+  const repaired = JSON.parse(JSON.stringify(geminiToolSchema(schema)));
+  assert.deepEqual(repaired.required, ["__proto__"]);
+  assert.equal(repaired.additionalProperties, false);
+  assert.ok(Object.hasOwn(repaired.properties, "__proto__"));
+  assert.deepEqual(repaired.properties.__proto__, {
+    anyOf: [{ type: "array", items: { type: "string" }, minItems: 1, maxItems: 2 }, { type: "null" }],
+  });
+});
+
+test("nested schema positions are repaired in place", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      list: {
+        type: "array",
+        // A nullable element schema, one level deeper than the observed field.
+        items: { type: ["string", "null"] },
+      },
+      bag: { type: "object", additionalProperties: { type: ["number", "null"] } },
+    },
+  };
+  const repaired = geminiToolSchema(schema);
+  assert.deepEqual(repaired.properties.list.items, {
+    anyOf: [{ type: "string" }, { type: "null" }],
+  });
+  assert.deepEqual(repaired.properties.bag.additionalProperties, {
+    anyOf: [{ type: "number" }, { type: "null" }],
+  });
+  assert.deepEqual(schema.properties.list.items, { type: ["string", "null"] });
+});
+
+test("the tool walker repairs parameters and inputSchema and keeps identity", () => {
+  const parameters = imageGenParameters();
+  const tool = {
+    type: "function",
+    name: "image_gen__imagegen",
+    description: "Generate or edit images.",
+    parameters,
+    inputSchema: parameters,
+  };
+  const repaired = repairGeminiToolSchema(tool);
+  assert.equal(repaired.type, "function");
+  assert.equal(repaired.name, "image_gen__imagegen");
+  assert.equal(repaired.description, "Generate or edit images.");
+  assert.deepEqual(repaired.parameters.properties.referenced_image_paths, {
+    anyOf: [
+      {
+        type: "array",
+        items: { type: "string" },
+        description: "Paths to images the edit should reference.",
+      },
+      { type: "null" },
+    ],
+  });
+  assert.deepEqual(repaired.inputSchema, repaired.parameters);
+  assert.ok(repaired.inputSchema.properties.referenced_image_paths.anyOf);
+  // The caller's tool is not mutated, and a clean tool keeps its identity.
+  assert.deepEqual(tool.parameters, parameters);
+  const clean = { type: "function", name: "plain", parameters: { type: "object", properties: {} } };
+  assert.equal(repairGeminiToolSchema(clean), clean);
+  const list = [clean];
+  assert.equal(repairGeminiToolSchemas(list), list);
+});
+
+test("namespace entries keep their shape and have children repaired", () => {
+  const namespace = {
+    type: "namespace",
+    name: "image_gen",
+    description: "Media tools.",
+    tools: [
+      {
+        type: "function",
+        name: "imagegen",
+        inputSchema: imageGenParameters(),
+      },
+    ],
+  };
+  const repaired = repairGeminiToolSchemas([namespace]);
+  assert.equal(repaired.length, 1);
+  assert.equal(repaired[0].type, "namespace");
+  assert.equal(repaired[0].name, "image_gen");
+  assert.equal(repaired[0].description, "Media tools.");
+  assert.equal(repaired[0].tools[0].name, "imagegen");
+  assert.deepEqual(repaired[0].tools[0].inputSchema.properties.num_last_images_to_include, {
+    anyOf: [{ type: "number" }, { type: "null" }],
+  });
+
+  const cleanNamespace = {
+    type: "namespace",
+    name: "clean",
+    tools: [{ type: "function", name: "child", inputSchema: { type: "object" } }],
+  };
+  assert.equal(repairGeminiToolSchema(cleanNamespace), cleanNamespace);
+});

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -12122,3 +12122,81 @@ test("an oversize zstd body is refused with 413 before decoding and the router s
     await closeServer(gateway.server);
   }
 });
+
+test("Command Code Gemini repairs nullable schemas after namespace and search expansion only on the affected route", async () => {
+  const captured = [];
+  const gateway = await mockServer(async (request, response) => {
+    captured.push(await bodyJson(request));
+    json(response, 200, {
+      id: "resp-gemini-schema", object: "response",
+      output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "ok" }] }],
+    });
+  });
+  const scratch = mkdtempSync(path.join(os.tmpdir(), "gemini-tool-schemas-"));
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_HOME: path.join(scratch, "codex"),
+    MODEL_ROUTER_STATE_DIR: path.join(scratch, "state"),
+    CODEX_ROUTER_STATE_DIR: path.join(scratch, "state"),
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const parameters = {
+    type: "object",
+    properties: {
+      prompt: { type: "string" },
+      referenced_image_paths: { type: ["array", "null"], items: { type: "string" } },
+      num_last_images_to_include: { type: ["number", "null"] },
+    },
+    required: ["prompt"],
+  };
+  const namespace = { type: "namespace", name: "image_gen", tools: [
+    { type: "function", name: "imagegen", inputSchema: parameters },
+  ] };
+  const plain = { type: "function", name: "plain", parameters: { type: "object", properties: { value: {type: "string"} } } };
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    for (const model of ["commandcode/gemini-3.8-flash", "commandcode/gemini-3.7-flash", "openrouter/gemini-3.8-flash"]) {
+      for (const deferred of [false, true]) {
+        const input = [{ role: "user", content: "Schema compatibility check." }];
+        if (deferred) input.push(
+          { type: "tool_search_call", call_id: "search-schema", execution: "client", arguments: {query: "imagegen"} },
+          { type: "tool_search_output", call_id: "search-schema", execution: "client", status: "completed", tools: [namespace] },
+          { role: "user", content: "Use the discovered tools." },
+        );
+        const response = await fetch(`${routerBase(routerPort)}/responses`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${CALLER_KEY}` },
+          body: JSON.stringify({ model, input, tools: deferred ? [plain, {type: "tool_search", execution: "client"}] : [plain, namespace] }),
+        });
+        assert.equal(response.status, 200, router.testErrors());
+        await response.arrayBuffer();
+        const sent = captured.at(-1).tools;
+        assert.ok(sent.some(tool => tool.name === "plain"));
+        const imagegen = sent.find(tool => tool.name === "image_gen__imagegen");
+        assert.ok(imagegen, `${model}: image tool must be retained (deferred=${deferred})`);
+        for (const field of ["parameters", "inputSchema"]) {
+          const schema = imagegen[field];
+          assert.ok(schema, `${model}: ${field} must be retained`);
+          assert.deepEqual(schema.required, ["prompt"]);
+          assert.deepEqual(schema.properties.prompt, {type: "string"});
+          if (model === "commandcode/gemini-3.8-flash") {
+            assert.deepEqual(schema.properties.referenced_image_paths, {
+              anyOf: [{ type: "array", items: { type: "string" } }, { type: "null" }],
+            });
+            assert.deepEqual(schema.properties.num_last_images_to_include, {
+              anyOf: [{ type: "number" }, { type: "null" }],
+            });
+          } else {
+            assert.deepEqual(schema, parameters, `${model} must keep its existing schema`);
+          }
+        }
+      }
+    }
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(scratch, {recursive: true, force: true});
+  }
+});


### PR DESCRIPTION
Command Code's Gemini 3.8 Flash can reject a Codex turn before any tool runs when the supplied tools contain a nullable array. The reported rejection identifies the image-generation tool's `referenced_image_paths` parameter:

> schema specified other fields alongside any_of. When using any_of, it must be the only field set.

Normalize a single concrete type plus `null` into an explicit union on this provider/model route. The non-null branch keeps its constraints, so an array still declares its item type. For example:

```json
{"type":["array","null"],"items":{"type":"string"}}
```

becomes:

```json
{"anyOf":[{"type":"array","items":{"type":"string"}},{"type":"null"}]}
```

The compatibility pass runs after namespace flattening and tool-search history expansion, covering both initially supplied and later discovered definitions. It preserves tool identities, parameter requirements, and unrelated routes. The nullable rewrite skips nodes carrying composition, reference, or enum/const constraints, and nodes declaring several non-null types. Literal values in defaults and examples are not traversed as schemas.

The patch adds no dependency or model configuration change. It contains only this compatibility fix, its regression tests, and a changelog entry.

## Validation

- `npm run check` passed.
- `node --test --test-concurrency=2 --test-timeout=180000 test/gemini-tool-schema.test.mjs test/routing.test.mjs test/tool-schema-root.test.mjs test/namespace-relay.test.mjs test/namespace-relay-routing.test.mjs test/grok-reasoning-summary-compat.test.mjs test/reasoning-tag-stripper.test.mjs` passed: 400 tests, no failures or skips. Run with an isolated `CODEX_HOME` and no outer Router-state overrides, so the fixtures own their state directories.
- Removing only the new compatibility invocation makes the routing regression fail on the unrepaired schema. Restoring it makes the test pass.
- `git diff --check` passed.

The reported provider error and earlier local deployment motivated this fix. No new live provider request was made while preparing this PR. The converter test models the observed conversion; it is not a live Google or Command Code acceptance test. The full repository suite and other operating systems are left to CI.
