### PR TITLE
fix: keep the type a broken $ref cycle was declaring on Moonshot routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Kimi no longer rejects a recursive tool schema the router itself made
+  typeless.** Breaking a `$ref` cycle drops the reference and leaves the node
+  behind, and a node with nothing left in it declares no type -- the one shape
+  Moonshot answers with HTTP 400 `tools.function.parameters missing type in
+  anyOf properties`, the same rejection #641 fixed for client-supplied schemas.
+  The type pass that fix added runs in the router's Moonshot compatibility hop,
+  while the cycle breaking runs later in the forwarder, so a recursive schema on
+  a Kimi route arrived with the type already removed again (#726). The cycle
+  edge now carries the type its target declared -- read out of the definition
+  the reference named, never guessed, and never over a type the client wrote
+  itself. Scoped to the measured Moonshot routes: the blanking exists for Meta's
+  Console 400, that path was not re-measured here, and every other provider and
+  model keeps the exact wire payload it has today.
+
 - **Reasoning from Chat Completions models now shows in Codex.** LiteLLM's
   Chat Completions to Responses bridge opens the assistant message first and
   streams the model's reasoning under a fresh hashed item id per delta, with no

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -38,6 +38,7 @@ import {
 } from "./rate-limit-headers.mjs";
 import { recordRateLimitSnapshot } from "./rate-limit-state.mjs";
 import { recordProviderCooldown } from "./model-failover.mjs";
+import { moonshotSchemaRoute } from "./moonshot-schema-routes.mjs";
 import { cooldownScope } from "./provider-cooldown.mjs";
 import { canonicalProviderId, readProviderSelection } from "./provider-selection.mjs";
 import { stripImages, supportsImageInput } from "./vision-bridge.mjs";
@@ -402,7 +403,7 @@ function stripEncryptedToolSchemaAnnotations(payload, protocol) {
 // `nonRecursiveToolSchema` -- which blanks exactly the cycle-closing edge and
 // returns any other schema by identity -- is the whole fix. The namespace relay
 // already uses it for the same reason.
-function flattenRecursiveToolSchemas(payload, protocol) {
+function flattenRecursiveToolSchemas(payload, protocol, options) {
   if (!Array.isArray(payload.tools)) return;
   let changed = false;
   const tools = payload.tools.map((tool) => {
@@ -410,14 +411,14 @@ function flattenRecursiveToolSchemas(payload, protocol) {
       return tool;
     }
     if (protocol === "openai-responses") {
-      const flattened = nonRecursiveToolSchema(tool.parameters);
+      const flattened = nonRecursiveToolSchema(tool.parameters, options);
       if (flattened === tool.parameters) return tool;
       changed = true;
       return { ...tool, parameters: flattened };
     }
     const fn = tool.function;
     if (!fn || typeof fn !== "object" || Array.isArray(fn)) return tool;
-    const flattened = nonRecursiveToolSchema(fn.parameters);
+    const flattened = nonRecursiveToolSchema(fn.parameters, options);
     if (flattened === fn.parameters) return tool;
     changed = true;
     return { ...tool, function: { ...fn, parameters: flattened } };
@@ -875,7 +876,14 @@ function normalizeBody(buffer, contentType, route) {
   // needs a request profile of its own, which the single-valued field cannot
   // express.
   if (model.toolSchemaRecursion === "flatten") {
-    flattenRecursiveToolSchemas(payload, provider.protocol);
+    // The router's Moonshot pass declares the types this route needs, but it
+    // runs earlier and elsewhere; blanking a cycle-closing `$ref` here would
+    // undo that work and leave a typeless `{}` behind (#726). Only that route
+    // pays for carrying the type through -- every other provider keeps the
+    // exact wire payload it has today.
+    flattenRecursiveToolSchemas(payload, provider.protocol, {
+      keepBlankedTypes: moonshotSchemaRoute(provider.id, model.upstreamModel),
+    });
   }
   if (model.requestProfile === "clinepass") {
     delete payload.reasoning_effort;

--- a/src/moonshot-schema-routes.mjs
+++ b/src/moonshot-schema-routes.mjs
@@ -1,0 +1,21 @@
+// Moonshot accepts only pure `$ref` pointers into `#/$defs/`, and rejects the
+// whole request -- not the one tool -- over any other pointer (issue #353), a
+// definition reference carrying sibling keywords, or a node inside a union that
+// declares no `type` (issue #641). The OAuth and platform-key routes are
+// separate products, but their first-party validators share this schema flavor.
+// Console Go's Kimi K2.7 Code route has returned the same validator error
+// (#488), so it is included as an exact measured route without projecting the
+// behavior onto unrelated OpenCode Go models.
+//
+// The set lives here rather than in `router.mjs` because the tool-schema
+// repairs Moonshot needs do not all happen in one hop: the forwarder applies
+// the recursion flattening, and it must be able to ask the same question.
+const MOONSHOT_PROVIDER_IDS = new Set(["kimi-oauth", "kimi-api", "kimi-api-cn"]);
+const OPENCODE_GO_MOONSHOT_MODELS = new Set(["kimi-k2.7-code"]);
+
+export function moonshotSchemaRoute(providerId, upstreamModel) {
+  return (
+    MOONSHOT_PROVIDER_IDS.has(providerId) ||
+    (providerId === "opencode-go" && OPENCODE_GO_MOONSHOT_MODELS.has(upstreamModel))
+  );
+}

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -57,6 +57,7 @@ import {
   isEmptyCompletionPreludeLimitError,
 } from "./empty-completion-guard.mjs";
 import { itemLifecycleNormalizerTransform } from "./item-lifecycle-normalizer.mjs";
+import { moonshotSchemaRoute } from "./moonshot-schema-routes.mjs";
 import { reasoningTagStripperTransform } from "./reasoning-tag-stripper.mjs";
 import {
   ZaiResponsesCompatTransform,
@@ -1066,16 +1067,8 @@ function needsNonRecursiveToolSchemaCompatibility(route) {
 // schema flavor. Console Go's Kimi K2.7 Code route has now returned the same
 // validator error (#488), so include that exact measured route without
 // projecting the behavior onto unrelated OpenCode Go models.
-const MOONSHOT_PROVIDER_IDS = new Set(["kimi-oauth", "kimi-api", "kimi-api-cn"]);
-const OPENCODE_GO_MOONSHOT_MODELS = new Set(["kimi-k2.7-code"]);
-
 function needsMoonshotSchemaCompatibility(route) {
-  const providerId = providerForModel(route)?.id;
-  return (
-    MOONSHOT_PROVIDER_IDS.has(providerId) ||
-    (providerId === "opencode-go" &&
-      OPENCODE_GO_MOONSHOT_MODELS.has(route.upstreamModel))
-  );
+  return moonshotSchemaRoute(providerForModel(route)?.id, route.upstreamModel);
 }
 
 function zenFreeCompatibleInput(input, route) {

--- a/src/tool-schema-root.mjs
+++ b/src/tool-schema-root.mjs
@@ -166,7 +166,28 @@ function cycleClosingLocalRefs(schema) {
   return { closing, count };
 }
 
-function cloneWithoutClosingRefs(root, closing) {
+// The type a blanked cycle-closing `$ref` was declaring, read out of the target
+// it named rather than inferred from context. A definition that is a pure alias
+// for another is followed, with visited pointers tracked so a `$defs` cycle made
+// only of references terminates.
+function closingRefType(ref, root) {
+  const seen = new Set();
+  let node = resolveRef(ref, root);
+  while (isPlainObject(node) && !("type" in node) && typeof node.$ref === "string") {
+    if (seen.has(node.$ref)) return undefined;
+    seen.add(node.$ref);
+    node = resolveRef(node.$ref, root);
+  }
+  if (!isPlainObject(node)) return undefined;
+  const type = node.type;
+  if (typeof type === "string") return type;
+  if (Array.isArray(type) && type.length && type.every((entry) => typeof entry === "string")) {
+    return [...type];
+  }
+  return undefined;
+}
+
+function cloneWithoutClosingRefs(root, closing, keepTypes) {
   const clones = new WeakMap();
   const rootCopy = {};
   clones.set(root, rootCopy);
@@ -176,8 +197,12 @@ function cloneWithoutClosingRefs(root, closing) {
     const entries = Array.isArray(source)
       ? source.map((value, index) => [index, value])
       : Object.entries(source);
+    let blankedRef;
     for (const [key, value] of entries) {
-      if (key === "$ref" && closing.has(source)) continue;
+      if (key === "$ref" && closing.has(source)) {
+        blankedRef = value;
+        continue;
+      }
       if (!Array.isArray(value) && !isPlainObject(value)) {
         target[key] = value;
         continue;
@@ -190,15 +215,25 @@ function cloneWithoutClosingRefs(root, closing) {
       }
       target[key] = copy;
     }
+    // Only for the routes that ask for it. Dropping the reference otherwise
+    // leaves a bare `{}`, which declares no type -- the one shape Moonshot
+    // answers with `tools.function.parameters missing type in anyOf
+    // properties` (#726), so the router can manufacture that 400 out of a
+    // schema the client wrote correctly. Every sibling the client authored,
+    // `type` included, still wins; this only fills the gap blanking opened.
+    if (keepTypes && blankedRef !== undefined && !("type" in target)) {
+      const recovered = closingRefType(blankedRef, root);
+      if (recovered !== undefined) target.type = recovered;
+    }
   }
   return rootCopy;
 }
 
-export function nonRecursiveToolSchema(schema) {
+export function nonRecursiveToolSchema(schema, { keepBlankedTypes = false } = {}) {
   if (!isPlainObject(schema)) return schema;
   const { closing, count } = cycleClosingLocalRefs(schema);
   if (!count) return schema;
-  return cloneWithoutClosingRefs(schema, closing);
+  return cloneWithoutClosingRefs(schema, closing, keepBlankedTypes);
 }
 
 // Some strict upstream JSON-Schema validators reject Codex's private

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import { CODEX_APP_TOOLS } from "../src/codex-app-tools.mjs";
 import { toResponsesRequest } from "../src/grok-oauth-forwarder.mjs";
+import { moonshotSchemaRoute } from "../src/moonshot-schema-routes.mjs";
 import {
   declareSchemaTypes,
   hasObjectRoot,
@@ -886,4 +887,103 @@ test("a schema that already declares its types is returned by identity", () => {
   };
   assert.equal(declareSchemaTypes(clean), clean);
   assert.equal(declareSchemaTypes({ type: "object" }).type, "object");
+});
+
+test("blanking a cycle edge keeps the type it pointed at when the route asks", () => {
+  // #726: `declareSchemaTypes` runs in the router's Moonshot pass, but the
+  // forwarder breaks `$ref` cycles later. Left as a bare `{}` the node declares
+  // no type, which is exactly what Moonshot rejects with
+  // "tools.function.parameters missing type in anyOf properties" -- a 400 the
+  // router manufactured out of a schema the client wrote correctly.
+  const schema = {
+    type: "object",
+    properties: { root: { $ref: "#/$defs/Node" } },
+    $defs: {
+      Node: {
+        type: "object",
+        properties: { name: { type: "string" }, child: { $ref: "#/$defs/Node" } },
+      },
+      Tags: { type: "array", items: { $ref: "#/$defs/Tags" } },
+    },
+  };
+
+  const repaired = nonRecursiveToolSchema(schema, { keepBlankedTypes: true });
+  assert.deepEqual(repaired.$defs.Node.properties.child, { type: "object" });
+  assert.deepEqual(repaired.$defs.Tags.items, { type: "array" });
+  // The type is read from the target, so the definitions themselves survive.
+  assert.equal(repaired.$defs.Node.properties.name.type, "string");
+});
+
+test("every other route still gets the permissive blank it has today", () => {
+  // The opposite of the test above, and the reason this is opt-in: the blanking
+  // exists for Meta's Console 400, that path works, and it was not re-measured
+  // here. Its wire payload must not move.
+  const schema = {
+    type: "object",
+    properties: { root: { $ref: "#/$defs/Node" } },
+    $defs: { Node: { type: "object", properties: { child: { $ref: "#/$defs/Node" } } } },
+  };
+  assert.deepEqual(nonRecursiveToolSchema(schema).$defs.Node.properties.child, {});
+  assert.deepEqual(
+    nonRecursiveToolSchema(schema, { keepBlankedTypes: false }).$defs.Node.properties.child,
+    {},
+  );
+});
+
+test("a type the client wrote on the referencing node is never overwritten", () => {
+  const schema = {
+    type: "object",
+    properties: { root: { $ref: "#/$defs/Node" } },
+    $defs: {
+      Node: {
+        type: "object",
+        properties: {
+          child: { $ref: "#/$defs/Node", type: "string", description: "kept" },
+        },
+      },
+    },
+  };
+  const child = nonRecursiveToolSchema(schema, { keepBlankedTypes: true })
+    .$defs.Node.properties.child;
+  assert.equal(child.type, "string");
+  assert.equal(child.description, "kept");
+  assert.equal("$ref" in child, false);
+});
+
+test("an alias definition is followed, and a definition cycle of pure refs terminates", () => {
+  const aliased = {
+    type: "object",
+    properties: { root: { $ref: "#/$defs/Node" } },
+    $defs: {
+      Alias: { $ref: "#/$defs/Node" },
+      Node: { type: "object", properties: { child: { $ref: "#/$defs/Alias" } } },
+    },
+  };
+  assert.deepEqual(
+    nonRecursiveToolSchema(aliased, { keepBlankedTypes: true }).$defs.Node.properties.child,
+    { type: "object" },
+  );
+
+  // Nothing declares a type anywhere on the ring; the walk must stop rather
+  // than chase it, and the node stays open.
+  const ring = {
+    type: "object",
+    properties: { root: { $ref: "#/$defs/A" } },
+    $defs: { A: { $ref: "#/$defs/B" }, B: { $ref: "#/$defs/A" } },
+  };
+  const repaired = nonRecursiveToolSchema(ring, { keepBlankedTypes: true });
+  assert.equal(JSON.stringify(repaired).includes("$defs"), true);
+});
+
+test("the Moonshot schema route set is exactly the measured routes", () => {
+  for (const providerId of ["kimi-oauth", "kimi-api", "kimi-api-cn"]) {
+    assert.equal(moonshotSchemaRoute(providerId, "any-model"), true);
+  }
+  assert.equal(moonshotSchemaRoute("opencode-go", "kimi-k2.7-code"), true);
+  // Not projected onto the rest of Console Go, and not onto the providers that
+  // use the blanking for Meta's 400.
+  assert.equal(moonshotSchemaRoute("opencode-go", "muse-spark-1.2-contributor"), false);
+  assert.equal(moonshotSchemaRoute("opencode-go-responses", "muse-spark-1.2-contributor"), false);
+  assert.equal(moonshotSchemaRoute("opencode-free-responses", "muse-spark-1.3-contributor-free"), false);
+  assert.equal(moonshotSchemaRoute(undefined, undefined), false);
 });


### PR DESCRIPTION
Related to #726; this does not claim to close that issue.

## Scope

Only locally curated Moonshot models with `toolSchemaRecursion: "flatten"` reach the type-preserving path. No shipped Kimi model enables flattening. The route that produced #726 has not been established. Stock Kimi and other providers retain their existing behavior.

## Changes

- Preserve explicitly declared target types when flattening a recursive reference on opted-in Moonshot routes; follow aliases with cycle detection.
- Prefer the referencing node's type-implying siblings. Ambiguous enum/union siblings prevent fallback to a contradictory target type. Explicit types remain untouched.
- Accept null options with the same behavior as omitted options.
- Share the unchanged Moonshot route predicate between router and forwarder.
- Merge current main to clear the conflict.

## Deliberate limitation

An untyped recursive union such as `N = anyOf(string, ref N)` still leaves an open branch after flattening. Neither a concrete target type nor the provider's intended recursive semantics is established, so this patch does not guess a type. A regression test records that limitation. Reference-only rings likewise remain open.

## Verification

405/405 tests passed across tool-schema-root, generic-routing, routing, namespace-relay, registry, commandcode-forwarder, deepseek-responses-routing, and grok-tool-facade. `npm run check` and `git diff --check` passed.

The forwarder regression starts the real process against a local mock endpoint using a user-curated kimi-api model with flattening enabled. It verifies the typed edge, a non-Moonshot flattening control retaining `{}`, and a model without flattening retaining its reference. Additional regressions cover conflicting enum/const/items/prefixItems/properties siblings, ambiguous siblings, input immutability, and null options.

No live provider requests were made.