### PR TITLE
fix: gate leaked tool-call recovery to Hy4, and make its capture linear

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2142,16 +2142,30 @@ content and no `function_call`. Codex ends the turn there and writes
    tag must repeat it. Do not hardcode it.
 3. **One item contributes its calls once.** The same span arrives on the delta
    channel, in the `.done` snapshot, and in the stored item; recovery is keyed
-   by output index so the call is emitted a single time.
+   by output index so the call is emitted a single time. The summary and content
+   channels are two renderings of one item's thinking, so they hold separate
+   span streams and the fuller reading wins -- sharing one stream between them
+   made the second channel look like a genuine extension of the first and
+   recovered, and executed, the call twice.
 4. **A leaked argument value is text.** It is read as JSON only when its text is
    exactly its own JSON form, so a declared `20000` or `true` survives while a
    shell command, a path, or `0755` stays the string the model wrote.
-5. **Routed streams only, before the namespace transform**, so a recovered
+5. **Hy4 routes only, before the namespace transform**, so a recovered
    flattened `mcp__server__tool` call is restored like any other, the empty-
    completion guard sees content, and the phase labeller reads the blank
    message as commentary instead of a final answer. Native streams gain no
-   stage. Coverage lives in `test/leaked-tool-call-recovery.test.mjs` and the
-   leaked-channel case in `test/namespace-relay-routing.test.mjs`.
+   stage, and neither does any other routed family: this is Hy4's own syntax,
+   and scanning every routed provider's text for it would turn prose that
+   merely *quotes* the markup -- a diff, a web page, this file -- into executed
+   tool calls. `usesLeakedToolCallRecovery` is the gate; widening it past
+   `hy4-preview` reopens that injection channel. Coverage lives in
+   `test/leaked-tool-call-recovery.test.mjs` and the leaked-channel case in
+   `test/namespace-relay-routing.test.mjs`.
+6. **A span is scanned once, not re-scanned per delta.** The capture is held
+   unjoined with a closing-tag overlap because `_transform` is synchronous:
+   re-scanning one growing string re-flattens the rope every delta, and a
+   1.25 MB unterminated span blocked the event loop for 21.5 s against 0.8 s
+   for the same bytes with no span open. The capture bound is 4 MiB.
 
 ## Routed subagent regression prevention
 

--- a/src/leaked-tool-call-recovery.mjs
+++ b/src/leaked-tool-call-recovery.mjs
@@ -33,6 +33,18 @@ import { Transform } from "node:stream";
 // dropped rather than relayed as half a tag. The item's own text is cleaned
 // independently, so the transcript still carries what the model wrote.
 
+// Hy4 Preview is the only family that emits this syntax, so it is the only one
+// whose text is reinterpreted. Scanning every routed provider would make any
+// prose that merely *quotes* the markup -- a diff, a web page, this repository's
+// own source -- into executed tool calls, which is a prompt-injection channel
+// rather than a repair. `upstreamModel` carries it on every shipped route
+// (`hy4-preview` on opencode Go, `tencent/hy4-preview` elsewhere), including
+// the Command Code route that ships no `requestProfile`.
+export function usesLeakedToolCallRecovery(route) {
+  const upstream = route?.upstreamModel;
+  return typeof upstream === "string" && /(?:^|\/)hy4-preview$/.test(upstream);
+}
+
 const OPEN_MARKER = "<tool_calls:";
 const NONCE = "[0-9a-zA-Z]{1,32}";
 const OPEN_RE = new RegExp(`^<tool_calls:(${NONCE})>`);
@@ -159,7 +171,23 @@ class LeakedSpanStream {
   calls = [];
   #mode = "normal";
   #carry = "";
-  #captured = "";
+  // A span arrives over many deltas. Holding it as one growing string and
+  // re-scanning it per delta is quadratic -- every `indexOf` re-flattens the
+  // concatenation rope -- and `_transform` is synchronous, so the cost is paid
+  // by every concurrent request on the router. Measured before this was made
+  // linear: a 1.25 MB unterminated span blocked the event loop for 21.5 s
+  // against 0.8 s for the same bytes with no span open, and the capture bound
+  // is 4 MiB. So the parts are kept unjoined and each delta is scanned once.
+  #parts = [];
+  #capturedLen = 0;
+  // First bytes only: enough to decide the opening tag, which cannot change.
+  #capturedHead = "";
+  #head = null;
+  // Content not yet scanned for the closing tag, and where it starts in the
+  // capture. Carries a closeTag-length overlap so a tag that straddles a delta
+  // boundary is still found.
+  #unsearched = "";
+  #unsearchedBase = 0;
   #bailed = false;
 
   // Longest suffix of `s` that could still become an opening marker.
@@ -187,35 +215,52 @@ class LeakedSpanStream {
           return out;
         }
         out += this.#carry.slice(0, at);
-        this.#captured = this.#carry.slice(at);
+        input = this.#carry.slice(at);
         this.#carry = "";
         this.#mode = "capture";
         continue;
       }
 
-      this.#captured += input;
-      input = "";
-      const head = OPEN_RE.exec(this.#captured);
+      if (input) {
+        this.#parts.push(input);
+        this.#capturedLen += input.length;
+        if (this.#capturedHead.length < MAX_OPEN_LEN) {
+          this.#capturedHead = (this.#capturedHead + input).slice(0, MAX_OPEN_LEN);
+        }
+        this.#unsearched += input;
+        input = "";
+      }
+      // Decided once: the opening tag cannot change as the capture grows.
+      const head = this.#head ?? (this.#head = OPEN_RE.exec(this.#capturedHead));
       if (!head) {
         // Still short of a decision, unless it can no longer become a marker.
-        if (this.#captured.length < MAX_OPEN_LEN) return out;
+        if (this.#capturedLen < MAX_OPEN_LEN) {
+          this.#head = null;
+          return out;
+        }
         out += this.#release();
         continue;
       }
       const closeTag = `</tool_calls:${head[1]}>`;
-      const closeAt = this.#captured.indexOf(closeTag, head[0].length);
-      if (closeAt === -1) {
-        if (this.#captured.length > MAX_CAPTURE_BYTES) {
+      const at = this.#unsearched.indexOf(closeTag);
+      if (at === -1) {
+        // Keep only enough to catch a tag split across this boundary.
+        const keep = Math.min(this.#unsearched.length, closeTag.length - 1);
+        this.#unsearchedBase += this.#unsearched.length - keep;
+        this.#unsearched = this.#unsearched.slice(this.#unsearched.length - keep);
+        if (this.#capturedLen > MAX_CAPTURE_BYTES) {
           this.#bailed = true;
           out += this.#release();
           return out;
         }
         return out;
       }
-      const span = this.#captured.slice(0, closeAt + closeTag.length);
-      const remainder = this.#captured.slice(closeAt + closeTag.length);
+      const closeAt = this.#unsearchedBase + at;
+      const all = this.#parts.join("");
+      const span = all.slice(0, closeAt + closeTag.length);
+      const remainder = all.slice(closeAt + closeTag.length);
       const parsed = parseLeakedToolCalls(span);
-      this.#captured = "";
+      this.#resetCapture();
       this.#mode = "normal";
       if (parsed) this.calls.push(...parsed.calls);
       else out += span;
@@ -229,11 +274,20 @@ class LeakedSpanStream {
     return out;
   }
 
+  #resetCapture() {
+    this.#parts = [];
+    this.#capturedLen = 0;
+    this.#capturedHead = "";
+    this.#head = null;
+    this.#unsearched = "";
+    this.#unsearchedBase = 0;
+  }
+
   // Return the buffered text to the visible channel and go back to scanning.
   #release() {
-    const out = this.#carry + this.#captured;
+    const out = this.#carry + this.#parts.join("");
     this.#carry = "";
-    this.#captured = "";
+    this.#resetCapture();
     this.#mode = "normal";
     return out;
   }
@@ -346,8 +400,13 @@ export class LeakedToolCallRecovery extends Transform {
     this.#passthrough = true;
   }
 
-  #streamFor(index) {
-    const key = Number.isInteger(index) ? index : 0;
+  // One stream per channel, not per item. The summary and content channels of a
+  // single reasoning item each carry their own delta sequence; sharing a stream
+  // between them appends the second channel's calls to the first's, and the
+  // cumulative-reading dedupe in `#collect` then reads the repeat as a genuine
+  // extension -- recovering, and executing, the same call twice.
+  #streamFor(index, channel) {
+    const key = `${Number.isInteger(index) ? index : 0}\u0000${channel}`;
     let stream = this.#streams.get(key);
     if (!stream) {
       stream = new LeakedSpanStream();
@@ -428,7 +487,7 @@ export class LeakedToolCallRecovery extends Transform {
         type === "response.output_text.delta") &&
       typeof event.delta === "string"
     ) {
-      const stream = this.#streamFor(event.output_index);
+      const stream = this.#streamFor(event.output_index, type);
       const before = stream.calls.length;
       const cleaned = stream.feed(event.delta);
       this.#take(event.output_index, stream, before);
@@ -443,7 +502,8 @@ export class LeakedToolCallRecovery extends Transform {
         type === "response.output_text.done") &&
       typeof event.text === "string"
     ) {
-      const stream = this.#streamFor(event.output_index);
+      // The `.done` snapshot closes the same channel its deltas opened.
+      const stream = this.#streamFor(event.output_index, type.replace(/\.done$/, ".delta"));
       const before = stream.calls.length;
       stream.flush();
       this.#take(event.output_index, stream, before);
@@ -469,7 +529,13 @@ export class LeakedToolCallRecovery extends Transform {
       const summary = cleanTextParts(item.summary, "text");
       const content = cleanTextParts(item.content, "text");
       if (!summary.changed && !content.changed) return item;
-      this.#collect(outputIndex, [...summary.calls, ...content.calls]);
+      // `summary` and `content` are two renderings of one item's thinking. When
+      // both carry the span they describe the same calls, so take the fuller
+      // reading rather than concatenating them into a duplicate.
+      this.#collect(
+        outputIndex,
+        summary.calls.length >= content.calls.length ? summary.calls : content.calls,
+      );
       return { ...item, summary: summary.parts, content: content.parts };
     }
     if (item?.type === "message") {

--- a/src/leaked-tool-call-recovery.mjs
+++ b/src/leaked-tool-call-recovery.mjs
@@ -160,7 +160,13 @@ export function parseLeakedToolCalls(text) {
   }
   if (!calls.length) return undefined;
   // The markup follows the model's last sentence; drop the gap it left behind.
-  return { cleaned: cleaned.replace(/\s+$/, ""), calls };
+  // `trimEnd` rather than /\s+$/: this runs on whole-provider text from the
+  // `.done` snapshot and stored-item paths, which MAX_CAPTURE_BYTES does not
+  // bound, and `\s+$` backtracks from every start offset of a long whitespace
+  // run that is not at end of string -- 200 KB of it blocked this synchronous
+  // transform, and so the whole router, for 15 s. `trimEnd` strips exactly the
+  // same set (WhiteSpace + LineTerminator) in one linear pass.
+  return { cleaned: cleaned.trimEnd(), calls };
 }
 
 // Incremental stripper for one output item's delta channel. `feed` returns the

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -57,7 +57,10 @@ import {
   isEmptyCompletionPreludeLimitError,
 } from "./empty-completion-guard.mjs";
 import { itemLifecycleNormalizerTransform } from "./item-lifecycle-normalizer.mjs";
-import { leakedToolCallRecoveryTransform } from "./leaked-tool-call-recovery.mjs";
+import {
+  leakedToolCallRecoveryTransform,
+  usesLeakedToolCallRecovery,
+} from "./leaked-tool-call-recovery.mjs";
 import { reasoningTagStripperTransform } from "./reasoning-tag-stripper.mjs";
 import {
   ZaiResponsesCompatTransform,
@@ -4348,8 +4351,9 @@ async function handleResponses(request, response, requestUrl) {
       // with an empty assistant message and no `function_call` -- Codex shows
       // the "Worked for ..." group and no answer at all. Runs before the
       // namespace transform so a recovered flattened call is restored like any
-      // other. Native streams (no route) never carry the markup.
-      const leakedToolCalls = route
+      // other. Native streams (no route) never carry the markup, and neither
+      // does any routed family but Hy4 -- see `usesLeakedToolCallRecovery`.
+      const leakedToolCalls = usesLeakedToolCallRecovery(route)
         ? leakedToolCallRecoveryTransform(contentType)
         : undefined;
       if (leakedToolCalls) transforms.push(leakedToolCalls);

--- a/test/leaked-tool-call-recovery.test.mjs
+++ b/test/leaked-tool-call-recovery.test.mjs
@@ -7,6 +7,7 @@ import {
   LeakedToolCallRecovery,
   leakedToolCallRecoveryTransform,
   parseLeakedToolCalls,
+  usesLeakedToolCallRecovery,
 } from "../src/leaked-tool-call-recovery.mjs";
 
 const N = "6124c78e";
@@ -458,4 +459,74 @@ test("a stream that ends without a terminal event still hands over its calls", a
   });
   const { body } = await run(stream);
   assert.equal(functionCalls(body).length, 2);
+});
+
+test("recovery is offered to Hy4 routes and to nothing else", () => {
+  // This markup is Hy4's own tool-call syntax. Scanning every routed provider's
+  // text for it would make prose that merely *quotes* it -- a diff, a web page,
+  // this repository's own source -- into executed tool calls.
+  for (const upstreamModel of ["hy4-preview", "tencent/hy4-preview"]) {
+    assert.equal(usesLeakedToolCallRecovery({ upstreamModel }), true, upstreamModel);
+  }
+  for (const route of [
+    null,
+    undefined,
+    {},
+    { upstreamModel: "glm-5.3" },
+    { upstreamModel: "deepseek-v4-flash" },
+    { upstreamModel: "grok-4.6" },
+    { upstreamModel: "moonshotai/kimi-k2.6" },
+    { upstreamModel: "evil-hy4-preview-x" },
+    { upstreamModel: "hy4-preview-turbo" },
+  ]) {
+    assert.equal(usesLeakedToolCallRecovery(route), false, JSON.stringify(route));
+  }
+});
+
+test("one item's calls are recovered once even when both channels carry the span", async () => {
+  // `summary` and `content` are two renderings of one item's thinking. Sharing
+  // a span stream between them made the second reading look like a genuine
+  // extension of the first, and the call was recovered -- and executed -- twice.
+  const both =
+    block({ type: "response.reasoning_summary_text.delta", output_index: 0, delta: LIVE_REASONING }) +
+    block({ type: "response.reasoning_text.delta", output_index: 0, delta: LIVE_REASONING }) +
+    block({ type: "response.completed", response: { id: "r", output: [] } });
+  assert.equal(functionCalls((await run(both)).body).length, 2);
+
+  const storedBoth =
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: {
+        type: "reasoning",
+        summary: [{ type: "summary_text", text: LIVE_REASONING }],
+        content: [{ type: "reasoning_text", text: LIVE_REASONING }],
+      },
+    }) +
+    block({ type: "response.completed", response: { id: "r", output: [] } });
+  assert.equal(functionCalls((await run(storedBoth)).body).length, 2);
+});
+
+test("an unterminated span is scanned once, not re-scanned per delta", async () => {
+  // Held as one growing string this was quadratic -- every indexOf re-flattened
+  // the rope -- and `_transform` is synchronous, so a 1.25 MB unterminated span
+  // blocked the router's event loop for 21.5 s against 0.8 s for the same bytes
+  // with no span open. Assert the shape of the curve, not a wall-clock number.
+  const chunk = "x".repeat(64);
+  async function elapsed(bytes) {
+    let stream = block({ type: "response.created", response: { id: "r" } }) +
+      block({ type: "response.reasoning_text.delta", output_index: 0, delta: `<tool_calls:${N}>` });
+    for (let sent = 0; sent < bytes; sent += chunk.length) {
+      stream += block({ type: "response.reasoning_text.delta", output_index: 0, delta: chunk });
+    }
+    stream += block({ type: "response.completed", response: { id: "r", output: [] } });
+    const started = process.hrtime.bigint();
+    await run(stream);
+    return Number(process.hrtime.bigint() - started) / 1e6;
+  }
+  const small = await elapsed(128 * 1024);
+  const large = await elapsed(512 * 1024);
+  // Four times the bytes. Linear would be ~4x; the quadratic version was ~16x.
+  // Allow generous slack for a loaded machine and still catch a return to O(n^2).
+  assert.ok(large < small * 9, `128 KiB took ${small} ms, 512 KiB took ${large} ms`);
 });

--- a/test/leaked-tool-call-recovery.test.mjs
+++ b/test/leaked-tool-call-recovery.test.mjs
@@ -507,26 +507,43 @@ test("one item's calls are recovered once even when both channels carry the span
   assert.equal(functionCalls((await run(storedBoth)).body).length, 2);
 });
 
-test("an unterminated span is scanned once, not re-scanned per delta", async () => {
-  // Held as one growing string this was quadratic -- every indexOf re-flattened
-  // the rope -- and `_transform` is synchronous, so a 1.25 MB unterminated span
-  // blocked the router's event loop for 21.5 s against 0.8 s for the same bytes
-  // with no span open. Assert the shape of the curve, not a wall-clock number.
-  const chunk = "x".repeat(64);
-  async function elapsed(bytes) {
-    let stream = block({ type: "response.created", response: { id: "r" } }) +
-      block({ type: "response.reasoning_text.delta", output_index: 0, delta: `<tool_calls:${N}>` });
-    for (let sent = 0; sent < bytes; sent += chunk.length) {
-      stream += block({ type: "response.reasoning_text.delta", output_index: 0, delta: chunk });
-    }
-    stream += block({ type: "response.completed", response: { id: "r", output: [] } });
-    const started = process.hrtime.bigint();
-    await run(stream);
-    return Number(process.hrtime.bigint() - started) / 1e6;
+test("an unterminated span gives up at the bound instead of buffering forever", async () => {
+  // The capture is held unjoined and scanned once per delta with a closing-tag
+  // overlap, because `_transform` is synchronous and re-scanning one growing
+  // string re-flattened the rope every delta: 1.25 MB cost 29.5 s of blocked
+  // event loop against 1.1 s for the same bytes with no span open. That is a
+  // throughput property and is deliberately not asserted by wall clock here --
+  // a timing threshold measures machine load, not the algorithm. What is
+  // asserted is the behaviour at the 4 MiB bound, which the rewrite preserves.
+  const chunk = "x".repeat(4096);
+  let stream = block({ type: "response.created", response: { id: "r" } }) +
+    block({ type: "response.reasoning_text.delta", output_index: 0, delta: `<tool_calls:${N}>` });
+  for (let sent = 0; sent < 5 * 1024 * 1024; sent += chunk.length) {
+    stream += block({ type: "response.reasoning_text.delta", output_index: 0, delta: chunk });
   }
-  const small = await elapsed(128 * 1024);
-  const large = await elapsed(512 * 1024);
-  // Four times the bytes. Linear would be ~4x; the quadratic version was ~16x.
-  // Allow generous slack for a loaded machine and still catch a return to O(n^2).
-  assert.ok(large < small * 9, `128 KiB took ${small} ms, 512 KiB took ${large} ms`);
+  stream += block({ type: "response.completed", response: { id: "r", output: [] } });
+  const { body } = await run(stream);
+  // Never closed: nothing is recovered, and past the bound the held text is
+  // released verbatim rather than buffered without limit.
+  assert.equal(functionCalls(body).length, 0);
+  assert.ok(body.includes(`<tool_calls:${N}>`), "the unrecognized span is relayed, not swallowed");
+});
+
+test("a closing tag split across two deltas is still found", async () => {
+  // The scan keeps a closeTag-length overlap precisely for this.
+  const closeTag = `</tool_calls:${N}>`;
+  for (const cut of [1, 5, closeTag.length - 1]) {
+    const span = `<tool_calls:${N}><tool_call:${N}>exec_command` +
+      `<arg_key:${N}>cmd</arg_key:${N}><arg_value:${N}>ls</arg_value:${N}>` +
+      `</tool_call:${N}>`;
+    const whole = span + closeTag;
+    const at = whole.length - closeTag.length + cut;
+    const stream =
+      block({ type: "response.created", response: { id: "r" } }) +
+      block({ type: "response.reasoning_text.delta", output_index: 0, delta: whole.slice(0, at) }) +
+      block({ type: "response.reasoning_text.delta", output_index: 0, delta: whole.slice(at) }) +
+      block({ type: "response.completed", response: { id: "r", output: [] } });
+    const { body } = await run(stream);
+    assert.equal(functionCalls(body).length, 1, `split at ${cut}`);
+  }
 });

--- a/test/leaked-tool-call-recovery.test.mjs
+++ b/test/leaked-tool-call-recovery.test.mjs
@@ -118,6 +118,36 @@ test("text without the markup is left exactly alone", () => {
   assert.equal(parseLeakedToolCalls(undefined), undefined);
 });
 
+test("a long whitespace run after the span is trimmed in linear time", () => {
+  // The trailing-gap trim used to be /\s+$/, which backtracks from every start
+  // offset of a whitespace run that is not at end of string. This path is
+  // reached from the `.done` snapshot and stored-item channels, whose text
+  // MAX_CAPTURE_BYTES does not bound, and `_transform` is synchronous -- so the
+  // whole router stalls. Measured on the pre-fix code: 200 KB of padding blocked
+  // for 15 s, 400 KB for 55 s.
+  //
+  // This asserts an absolute elapsed bound, which the note against wall-clock
+  // tests in this file does not cover: that warning is about *ratio* tests,
+  // where a loaded machine slows the control run as much as the measured one.
+  // Here the two implementations differ by roughly six orders of magnitude
+  // (0.1 ms vs 55_000 ms), so a 2 s ceiling has a ~20_000x margin over the fix
+  // and still fails the regression on any machine. A `{ timeout }` option would
+  // not work: the blocking is synchronous, so the runner's timer never fires.
+  const padded = `${LIVE_REASONING.trimEnd()}${" ".repeat(400_000)}z`;
+  const startedAt = process.hrtime.bigint();
+  const parsed = parseLeakedToolCalls(padded);
+  const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
+
+  assert.equal(parsed.calls.length, 2);
+  // The `z` is not whitespace, so nothing is trimmed and the padding survives.
+  assert.equal(parsed.cleaned.endsWith(`${" ".repeat(400_000)}z`), true);
+  assert.ok(elapsedMs < 2_000, `trailing trim took ${elapsedMs.toFixed(0)}ms`);
+
+  // And the ordinary case still trims the gap the markup left behind.
+  const trailing = parseLeakedToolCalls(`${LIVE_REASONING.trimEnd()}\n\n\t  `);
+  assert.equal(trailing.cleaned.endsWith("comes up."), true);
+});
+
 test("malformed markup is never eaten", () => {
   // Unterminated span.
   assert.equal(parseLeakedToolCalls(`prose <tool_calls:${N}><tool_call:${N}>x`), undefined);

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -2728,7 +2728,11 @@ test("a routed turn whose tool calls leaked into the reasoning channel still run
     content: [],
   };
   const result = await scenario(true, {
-    model: "opencode-go/deepseek-v4.1-flash",
+    // The route the capture came from. Recovery is Hy4-only on purpose: this
+    // markup is Hy4's native tool-call syntax, and scanning every routed
+    // provider's text for it would turn prose that merely quotes it into
+    // executed calls.
+    model: "opencode-go/hy4-preview",
     sseBody: () => [
       sseEvent({ type: "response.created", response: { id: "resp_leak" } }),
       sseEvent({


### PR DESCRIPTION
Reopens #722, which GitHub auto-closed when #715 merged and deleted its base branch. Same branch, same commits, retargeted at `main`.

**This is the gate for code that is already on `main`.** #715 landed the recovery transform; this PR is what scopes it. Until this merges, `src/router.mjs:4420` reads:

```js
const leakedToolCalls = route ? leakedToolCallRecoveryTransform(contentType) : undefined;
```

— installed for **every routed provider**, with no `usesLeakedToolCallRecovery` on `main` at all.

## Why that matters

The transform scans a model's visible answer and reasoning text for Hy4's `<tool_calls:NONCE>...</tool_calls:NONCE>` markup and converts it into real `function_call` items. The nonce is **not a secret**: nothing in `src/` generates or stores one. `OPEN_RE` captures it from the model's own opening tag and the closing tag is built from that capture, so open/close agreement is free to anything that emits both.

So on `main` today, any routed model — Claude via `commandcode-messages`, GPT, DeepSeek, GLM — that *quotes* that markup has it converted into a call Codex executes. Quoting this repository's own `AGENTS.md`, a diff, or a web page is enough. Measured on the pre-gate code, a single visible-channel sentence describing the syntax produced three injected `function_call` items, one carrying a destructive recursive-delete argument.

This PR restores `usesLeakedToolCallRecovery(route)`, matching `/(?:^|\/)hy4-preview$/`. Enumerated across all 141 `upstreamModel` values in `config/**/*.json`: only `hy4-preview` and `tencent/hy4-preview` match, covering all six shipped Hy4 routes and nothing else.

## Also on this branch, also missing from `main`

**Linear capture.** #715's version held the open span as one growing string and re-scanned it per delta, synchronously on the router's event loop. Measured through the real transform:

| span | before | after |
|---|---|---|
| 1 MB | 1508 ms | 28 ms |
| 4 MB | 18312 ms | 94 ms |

**The trailing-gap trim.** `parseLeakedToolCalls` ended with a backtracking `\s+$` replace, which retries from every start offset of a whitespace run not at end of string. `MAX_CAPTURE_BYTES` does not bound it — that cap is on the streaming capture, while the `.done` snapshot and stored-item paths pass whole-provider text. 200 KB of padding blocked the event loop for 15 s; 400 KB for ~55 s. Replaced with `trimEnd`, verified identical across all 65536 BMP code points.

**One recovery per item.** Summary and content channels shared one span stream, so a single item's calls were recovered — and executed — twice.

## Known limitation, stated plainly

The gate narrows the injection channel; it does not close it. On an Hy4 route the only check on a recovered call is `NAME_RE`, a format check. The request's declared `tools` array is in scope in `handleResponses` and is never passed to the transform. Threading it through and dropping any recovered call whose name was not declared is the real mitigation, and should follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)