### PR TITLE
fix: keep an explicit subagent model instead of pinning it to the routed parent

### DIFF
--- a/.claude/skills/codex-subagents/SKILL.md
+++ b/.claude/skills/codex-subagents/SKILL.md
@@ -118,6 +118,19 @@ what Codex is allowed to choose.
 For parallel work, ask for several in one message so they run concurrently rather
 than in sequence.
 
+## Delegating from a routed parent to a native OpenAI model
+
+The router writes `expose_spawn_agent_model_overrides = true` into the managed
+`multi_agent_v2` block, so Codex offers a model override on `spawn_agent` for
+every session, routed parent included. Name the child model when you ask:
+
+> spawn a subagent on gpt-6-astra to audit src/router.mjs
+
+Codex checks the name against its own override list and rejects anything it does
+not offer, so an unavailable model fails before a turn is spent. The router
+keeps the override instead of pinning the child back to the parent's model; only
+a spawn call that omits the model inherits the parent.
+
 ## When it goes wrong
 
 **Model not offered in Codex.** Run the report. Not listed → `subagents set <slug> on`,

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -395,7 +395,11 @@ unprotected, or left over for a model that is no longer eligible, the installed
 picker is republished to restore the coupled catalog/agent state. An unreadable
 or foreign Codex transport is never repaired speculatively.
 
-Only registry-proven models are advertised as native v2 spawn-agent overrides.
+Only registry-proven models are advertised as native v2 spawn-agent overrides,
+and an explicit spawn model is kept: a child runs on the model the operator
+picked from Codex's own list instead of being pinned back to the routed parent.
+Codex checks that value against its list before the call is dispatched, so an
+override cannot name a route the operator was never offered.
 The Settings tab (desktop panel and macOS tray) exposes two local accordions:
 **Subagent models** can withhold or re-enable proven models, while **Model
 picker** controls visibility. Local settings never promote an unverified model

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -607,13 +607,24 @@ function isSubagentSpawnCall(item) {
   return item.namespace === undefined && item.name === `collaboration${NAMESPACE_DELIMITER}spawn_agent`;
 }
 
-// Inject the session model into local create_thread calls that omitted it and
-// pin every spawn_agent call to the routed parent. A parent not offered by the
-// client then fails closed at tool validation instead of silently crossing a
-// billing boundary.
-// `model` is the routed session's model (route.slug). Returns a rewritten
-// item when a local create_thread carries no explicit model or a spawn_agent
-// model differs from the routed parent; otherwise returns the item untouched.
+// Inject the session model into local create_thread calls that omitted it, and
+// into spawn_agent calls that carry no model of their own.
+//
+// An explicit subagent model wins. Codex ships the override as a plain string
+// on the tool schema rather than a schema enum, and validates the value against
+// its own advertised list, so anything that reaches here is the operator's own
+// delegation choice and not a value the parent model invented. Rewriting it
+// back to the routed parent discarded that choice and made a cross-provider
+// subagent impossible from any routed session, which is the one thing
+// `expose_spawn_agent_model_overrides = true` exists to allow.
+//
+// `sanitizeSpawnAgentModel` still drops a value outside the advertised set when
+// a client version does ship one, so that guard is unaffected: the item it
+// clears arrives here without a model and inherits the parent as before.
+//
+// `model` is the routed session's model (route.slug). Returns a rewritten item
+// only when the call carries no model of its own; otherwise returns the item
+// untouched.
 export function injectSessionModelForSpawnCalls(item, model) {
   if (!isSpawnModelCall(item)) return item;
   if (typeof model !== "string" || !model) return item;
@@ -628,7 +639,7 @@ export function injectSessionModelForSpawnCalls(item, model) {
   if (typeof args !== "object" || args === null || Array.isArray(args)) return item;
   if (args.model !== undefined && !isSubagentSpawnCall(item)) return item;
   if (args.target?.type === "chatgptWorkCloud") return item;
-  if (args.model === model) return item;
+  if (typeof args.model === "string" && args.model) return item;
   return { ...item, arguments: JSON.stringify({ ...args, model }) };
 }
 

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -2313,7 +2313,7 @@ test("response transform restores namespace on unambiguous unprefixed calls", as
   assert.match(output, /"namespace":"codex_app"/);
 });
 
-test("response transform pins spawn-agent model overrides to the routed parent", async () => {
+test("response transform pins only an unadvertised spawn-agent override to the routed parent", async () => {
   const { namespaces } = flattenNamespaceTools(clientRoutedTools());
   const lookups = buildNamespaceLookups(namespaces);
   const invalid = rewriteNamespaceResponsePayload(
@@ -2365,7 +2365,9 @@ test("response transform pins spawn-agent model overrides to the routed parent",
     model: "opencode-go/deepseek-v4-flash",
   });
 
-  const allowedButCrossProvider = rewriteNamespaceResponsePayload(
+  // The client advertised this model, so it is a deliberate delegation target
+  // and survives a routed parent instead of being pinned back to it.
+  const advertisedCrossProvider = rewriteNamespaceResponsePayload(
     {
       output: [
         {
@@ -2378,9 +2380,9 @@ test("response transform pins spawn-agent model overrides to the routed parent",
     lookups,
     "opencode-go/deepseek-v4-flash",
   );
-  assert.deepEqual(JSON.parse(allowedButCrossProvider.output[0].arguments), {
+  assert.deepEqual(JSON.parse(advertisedCrossProvider.output[0].arguments), {
     message: "verify",
-    model: "opencode-go/deepseek-v4-flash",
+    model: "gpt-5.6-terra",
   });
 });
 

--- a/test/subagent-model-inherit.test.mjs
+++ b/test/subagent-model-inherit.test.mjs
@@ -3,7 +3,10 @@ import test from "node:test";
 
 import {
   SPAWN_MODEL_TOOLS,
+  buildNamespaceLookups,
+  flattenNamespaceTools,
   injectSessionModelForSpawnCalls,
+  rewriteNamespaceResponsePayload,
 } from "../src/namespace-relay.mjs";
 
 const SESSION_MODEL = "opencode-go/deepseek-v4-flash";
@@ -91,12 +94,15 @@ test("explicit model on a fresh thread wins and stays untouched", () => {
   assert.equal(injectSessionModelForSpawnCalls(namespaced, SESSION_MODEL), namespaced);
 });
 
-test("explicit subagent model is pinned to its routed parent", () => {
+test("an explicit subagent model is kept instead of pinned to the routed parent", () => {
+  // Codex renders the override as a plain string and validates it against its
+  // own list, so a value here is the operator's delegation choice. Rewriting it
+  // back to the parent is what made cross-provider subagents impossible.
   for (const subagent of [
     spawnCall(
       "collaboration__spawn_agent",
       undefined,
-      JSON.stringify({ task_name: "review", message: "inspect", model: "gpt-5.6-sol" }),
+      JSON.stringify({ task_name: "review", message: "inspect", model: "gpt-6-astra" }),
     ),
     spawnCall(
       "spawn_agent",
@@ -104,14 +110,39 @@ test("explicit subagent model is pinned to its routed parent", () => {
       JSON.stringify({ task_name: "review", message: "inspect", model: "gpt-5.6-sol" }),
     ),
   ]) {
-    const next = injectSessionModelForSpawnCalls(subagent, SESSION_MODEL);
-    assert.notEqual(next, subagent);
-    assert.deepEqual(JSON.parse(next.arguments), {
-      task_name: "review",
-      message: "inspect",
-      model: SESSION_MODEL,
-    });
+    assert.equal(injectSessionModelForSpawnCalls(subagent, SESSION_MODEL), subagent);
   }
+});
+
+test("an unusable spawn model still inherits the routed parent", () => {
+  // Absent, empty, and non-string values carry no override, so the child keeps
+  // the routed parent exactly as it did before.
+  const cases = [
+    { task_name: "review", message: "inspect" },
+    { task_name: "review", message: "inspect", model: "" },
+    { task_name: "review", message: "inspect", model: null },
+    { task_name: "review", message: "inspect", model: 7 },
+  ];
+  for (const args of cases) {
+    for (const build of [
+      (value) => spawnCall("collaboration__spawn_agent", undefined, JSON.stringify(value)),
+      (value) => spawnCall("spawn_agent", "collaboration", JSON.stringify(value)),
+    ]) {
+      const subagent = build(args);
+      const next = injectSessionModelForSpawnCalls(subagent, SESSION_MODEL);
+      assert.notEqual(next, subagent);
+      assert.equal(JSON.parse(next.arguments).model, SESSION_MODEL);
+    }
+  }
+});
+
+test("a spawned model equal to the routed parent is left untouched", () => {
+  const item = spawnCall(
+    "collaboration__spawn_agent",
+    undefined,
+    JSON.stringify({ task_name: "review", message: "inspect", model: SESSION_MODEL }),
+  );
+  assert.equal(injectSessionModelForSpawnCalls(item, SESSION_MODEL), item);
 });
 
 test("chatgptWorkCloud create_thread calls omit model", () => {
@@ -167,4 +198,79 @@ test("injection is idempotent once the model is present", () => {
     JSON.stringify({ prompt: "hi", model: SESSION_MODEL }),
   );
   assert.equal(injectSessionModelForSpawnCalls(item, SESSION_MODEL), item);
+});
+
+// `sanitizeSpawnAgentModel` polices an advertised enum when a client version
+// ships one, so that split is exercised end to end through the real
+// flatten/lookup/rewrite path instead of by calling the helper directly.
+function routedCollaborationTools(models) {
+  return [
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [
+        {
+          type: "function",
+          name: "spawn_agent",
+          inputSchema: {
+            type: "object",
+            properties: {
+              model: {
+                anyOf: [{ type: "string", enum: models }, { type: "null" }],
+              },
+            },
+          },
+        },
+      ],
+    },
+  ];
+}
+
+function flattenedSpawnPayload(model) {
+  return {
+    output: [
+      {
+        type: "function_call",
+        name: "collaboration__spawn_agent",
+        call_id: "call_1",
+        arguments: JSON.stringify({ task_name: "review", model }),
+      },
+    ],
+  };
+}
+
+test("the client's advertised enum reaches the wire rewrite and is preserved", () => {
+  const { namespaces } = flattenNamespaceTools(
+    routedCollaborationTools(["gpt-6-astra", "gpt-5.6-sol"]),
+  );
+  const lookups = buildNamespaceLookups(namespaces);
+  assert.ok(lookups.spawnAgentModels.has("gpt-6-astra"));
+
+  const rewritten = rewriteNamespaceResponsePayload(
+    flattenedSpawnPayload("gpt-6-astra"),
+    lookups,
+    SESSION_MODEL,
+  );
+  const item = rewritten.output[0];
+  assert.equal(item.name, "spawn_agent");
+  assert.equal(item.namespace, "collaboration");
+  assert.equal(JSON.parse(item.arguments).model, "gpt-6-astra");
+});
+
+test("a wire model outside the advertised enum is still pinned to the parent", () => {
+  const { namespaces } = flattenNamespaceTools(
+    routedCollaborationTools(["gpt-6-astra", "gpt-5.6-sol"]),
+  );
+  const lookups = buildNamespaceLookups(namespaces);
+
+  // `gpt-5.6-terra` is a real catalog entry the client did not advertise for
+  // this session, so it is still treated as an invented value.
+  const rewritten = rewriteNamespaceResponsePayload(
+    flattenedSpawnPayload("gpt-5.6-terra"),
+    lookups,
+    SESSION_MODEL,
+  );
+  const item = rewritten.output[0];
+  assert.equal(item.name, "spawn_agent");
+  assert.equal(JSON.parse(item.arguments).model, SESSION_MODEL);
 });


### PR DESCRIPTION
## Problem

`codex-router` writes `expose_spawn_agent_model_overrides = true` into the
managed `multi_agent_v2` block, so Codex offers a model override on
`spawn_agent`. The router then discarded that override:
`injectSessionModelForSpawnCalls` rewrote `spawn_agent.model` to the routed
parent on every call.

The effect is that a routed parent can only spawn copies of itself.
Cross-provider delegation, such as a DeepSeek parent delegating to a native
OpenAI model, is impossible even though the picker exists and
`subagent-report.mjs` lists those models as spawnable.

Reproduced on a live routed session:

- a child requested on `gpt-6-astra` reported `deepseek/deepseek-v4-flash`
- a child requested with a bogus model id also ran as the parent, with no
  client-side validation error

## Change

Keep an explicit subagent model; only a call that omits the model inherits the
parent. This mirrors what the router already does for `create_thread`.

There is no enum to police here. Codex ships `model` on the tool schema as a
plain string:

```json
{"type":"string","description":"Model override for the new agent. Omit unless an explicit override is needed."}
```

so `sanitizeSpawnAgentModel` never fires against a current client. Codex
validates the value itself and rejects anything outside its list:

```
Unknown model `totally-bogus-model-xyz` for spawn_agent. Available models:
gpt-6-astra, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5
```

An invented name therefore still cannot cross a billing boundary. The sanitizer
keeps its guard for a client version that does ship an enum: the item it clears
arrives without a model and inherits the parent as before.

## Testing

- `test/subagent-model-inherit.test.mjs` covers a kept explicit model, the
  absent/empty/non-string cases that still inherit the parent, and the
  wire-level preserve-or-inherit split driven through the real
  `flattenNamespaceTools` -> `buildNamespaceLookups` ->
  `rewriteNamespaceResponsePayload` path.
- `test/namespace-relay.test.mjs`: the existing pin test now asserts that an
  advertised override survives and that only an unadvertised one is pinned.
- `node --test` over the namespace-relay, namespace-relay-routing,
  subagent-completion, subagent-model-inherit and catalog suites: 259 pass, 0
  fail.
- `node scripts-check.mjs` passes.
- Live from a routed parent after the change, the router served child turns on
  `gpt-6-astra` and on `gpt-5.6-luna` per its own request log. Before the change
  the same calls were served on the parent.
